### PR TITLE
make build.rs be rebuilt upon generator change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+const GENERATOR: &str = "code_tables_generator.py";
+
 fn main() {
     let paths: Vec<PathBuf> = vec![
         ["src", "codes", "unary_tables.rs"].iter().collect(),
@@ -7,11 +9,16 @@ fn main() {
         ["src", "codes", "delta_tables.rs"].iter().collect(),
         ["src", "codes", "zeta_tables.rs"].iter().collect(),
     ];
-    // generate the tables if needed
-    if paths.iter().any(|path| !path.exists()) {
-        std::process::Command::new("python3")
-            .arg("./code_tables_generator.py")
-            .spawn()
-            .unwrap();
-    }
+
+    // rebuild if the generator has changed
+    println!("cargo:rerun-if-changed={GENERATOR}");
+    // rebuild if the target files have changed (in fact: vanished)
+    paths
+        .iter()
+        .for_each(|path| println!("cargo:rerun-if-changed={}", path.display()));
+
+    std::process::Command::new("python3")
+        .arg(GENERATOR)
+        .spawn()
+        .unwrap();
 }


### PR DESCRIPTION
This change make build.rs slightly more robust, in particular it informs cargo that it needs to be rebuilt if the generator python script changes and/or when the generated file themselves disappear.

It is still not ideal, because currently we are not following the build.rs recommendation [1] (e.g., we should generate code under env::var_os("OUT_DIR") and include() it from real Rust modules like in [2], rather than generating the actual modules under src), but it's an improvement over the status quo.

[1]: https://doc.rust-lang.org/cargo/reference/build-scripts.html
[2]: https://doc.rust-lang.org/cargo/reference/build-script-examples.html