### PR TITLE
make all Python build scripts Flake8- and Black- clean

### DIFF
--- a/code_tables_plot.py
+++ b/code_tables_plot.py
@@ -20,39 +20,55 @@ for code in ["unary", "gamma", "delta", "zeta3"]:
                 marker = "s"
 
             for pat in [
-                "%s::L2M::Table"%code,
-                "%s::M2L::Table"%code,
+                "%s::L2M::Table" % code,
+                "%s::M2L::Table" % code,
             ]:
-                values = df[(df.pat == pat) & (df.type == ty) & (df.tables_num == tables_n)]
+                values = df[
+                    (df.pat == pat) & (df.type == ty) & (df.tables_num == tables_n)
+                ]
                 m = min(values.ns_median)
                 i = np.argmin(values.ns_median)
                 plt.errorbar(
-                    values.n_bits, values.ns_median, #values.ns_std,
-                    label="{}::{}::{} (min: {:.3f}ns {} bits)".format("::".join(pat.split("::")[1:]), table_txt, ty, m, i), 
+                    values.n_bits,
+                    values.ns_median,  # values.ns_std,
+                    label="{}::{}::{} (min: {:.3f}ns {} bits)".format(
+                        "::".join(pat.split("::")[1:]), table_txt, ty, m, i
+                    ),
                     marker=marker,
                 )
                 plt.fill_between(
-                    values.n_bits, values.ns_perc25, values.ns_perc75, 
+                    values.n_bits,
+                    values.ns_perc25,
+                    values.ns_perc75,
                     alpha=0.3,
                 )
 
         for pat in [
-            "%s::L2M::NoTable"%code,
-            "%s::M2L::NoTable"%code,
-        ]:  
+            "%s::L2M::NoTable" % code,
+            "%s::M2L::NoTable" % code,
+        ]:
             values = df[(df.pat == pat) & (df.type == ty)].groupby("n_bits").mean()
             m = min(values.ns_median)
             plt.errorbar(
-                values.index, values.ns_median, #values.ns_std,
-                label="{}::{} (min: {:.3f}ns)".format("::".join(pat.split("::")[1:]), ty, m, i), 
+                values.index,
+                values.ns_median,  # values.ns_std,
+                label="{}::{} (min: {:.3f}ns)".format(
+                    "::".join(pat.split("::")[1:]), ty, m
+                ),
                 marker="^",
             )
             plt.fill_between(
-                values.index, values.ns_perc25, values.ns_perc75, 
+                values.index,
+                values.ns_perc25,
+                values.ns_perc75,
                 alpha=0.3,
             )
 
-    ratios = df[df.pat.str.contains(code) & (df.tables_num == tables_n)].groupby("n_bits").mean()
+    ratios = (
+        df[df.pat.str.contains(code) & (df.tables_num == tables_n)]
+        .groupby("n_bits")
+        .mean()
+    )
     bars = plt.bar(
         ratios.index,
         ratios.ratio,
@@ -61,13 +77,14 @@ for code in ["unary", "gamma", "delta", "zeta3"]:
         linewidth=1,
         edgecolor="black",
     )
-    for ratio,rect in zip(ratios.ratio, bars):
+    for ratio, rect in zip(ratios.ratio, bars):
         height = rect.get_height()
         plt.text(
-            rect.get_x() + rect.get_width() / 2.0, 1.2, 
-            "{:.2f}%".format(ratio * 100), 
-            ha='center', 
-            va='bottom',
+            rect.get_x() + rect.get_width() / 2.0,
+            1.2,
+            "{:.2f}%".format(ratio * 100),
+            ha="center",
+            va="bottom",
             rotation=90,
         )
 
@@ -80,14 +97,21 @@ for code in ["unary", "gamma", "delta", "zeta3"]:
         "--",
         alpha=0.3,
         color="gray",
-        label="table hit ratio 100% line"
+        label="table hit ratio 100% line",
     )
-        
-    plt.legend(loc='center left', bbox_to_anchor=(1, 0.5))
-    plt.ylim(bottom=0) #ymin is your value
-    plt.xlim([left, right]) #ymin is your value
+
+    plt.legend(loc="center left", bbox_to_anchor=(1, 0.5))
+    plt.ylim(bottom=0)  # ymin is your value
+    plt.xlim([left, right])  # ymin is your value
     plt.xticks(ratios.index)
-    plt.title("Performances of %s codes read and writes in function of the table size\nShaded areas are the 25%% and 75%% percentiles and the plots are medians with stds."%(code.capitalize()))
+    plt.title(
+        (
+            "Performances of %s codes read and writes in function of the table size\n"
+            "Shaded areas are the 25%% and 75%% percentiles and the plots "
+            "are medians with stds."
+        )
+        % (code.capitalize())
+    )
     plt.xlabel("Table Bits")
     plt.ylabel("ns")
-    plt.savefig("%s_tables.png"%code, bbox_inches="tight")
+    plt.savefig("%s_tables.png" % code, bbox_inches="tight")

--- a/code_tables_study.py
+++ b/code_tables_study.py
@@ -5,7 +5,13 @@ create a `table.csv` file with all the results
 import os
 import sys
 import subprocess
-from code_tables_generator import *
+from code_tables_generator import (
+    gen_unary,
+    gen_gamma,
+    gen_delta,
+    gen_zeta,
+    generate_default_tables,
+)
 
 for bits in range(1, 18):
     print("Table bits:", bits, file=sys.stderr)
@@ -18,22 +24,23 @@ for bits in range(1, 18):
 
         # Run the benchmark with native cpu optimizations
         stdout = subprocess.check_output(
-            "cargo run --release", shell=True,
+            "cargo run --release",
+            shell=True,
             env={
                 **os.environ,
-                "RUSTFLAGS":"-C target-cpu=native",
+                "RUSTFLAGS": "-C target-cpu=native",
             },
             cwd="benchmarks",
         ).decode()
 
         # Dump the header only the first time
         if bits == 1 and tables_num == 1:
-            print("n_bits,tables_num," + stdout.split('\n')[0])
+            print("n_bits,tables_num," + stdout.split("\n")[0])
         # Dump all lines and add the `n_bits` column
         for line in stdout.split("\n")[1:]:
             if len(line.strip()) != 0:
                 print("{},{},{}".format(bits, tables_num, line))
-        
+
         sys.stdout.flush()
 
 # Reset the tables to the original state

--- a/coverage.py
+++ b/coverage.py
@@ -6,7 +6,7 @@ import subprocess
 ROOT = os.path.dirname(os.path.abspath(__file__))
 target_folder = os.path.join(ROOT, "target")
 test_cov_path = os.path.join(target_folder, "test_cov.profraw")
-rustup_info =  subprocess.check_output("rustup show", shell=True).decode()
+rustup_info = subprocess.check_output("rustup show", shell=True).decode()
 arch = re.findall(r"Default host: (.+)", rustup_info)[0]
 # To run it needs the following:
 # cargo install rustfilt
@@ -19,57 +19,77 @@ final_cov_path = os.path.join(target_folder, "total_coverage.profdata")
 test_cov_path = os.path.join(target_folder, "test_cov.profdata")
 
 # Get the list of fuzzing targets
-fuzz_targets = subprocess.check_output(
-    "cargo fuzz list", 
-    shell=True, cwd=ROOT,
-).decode().split("\n")[:-1]
-# Clean up the targets folder 
+fuzz_targets = (
+    subprocess.check_output(
+        "cargo fuzz list",
+        shell=True,
+        cwd=ROOT,
+    )
+    .decode()
+    .split("\n")[:-1]
+)
+# Clean up the targets folder
 subprocess.check_call(
-    "cargo clean", 
-    shell=True, cwd=ROOT,
+    "cargo clean",
+    shell=True,
+    cwd=ROOT,
 )
 # Create a folder for the test coverage
 os.makedirs(target_folder, exist_ok=True)
 # Generate coverage from the test
 subprocess.check_call(
     "cargo test",
-    shell=True, cwd=ROOT,
+    shell=True,
+    cwd=ROOT,
     env={
         **os.environ,
-        "RUSTFLAGS":"-C instrument-coverage",
-        "LLVM_PROFILE_FILE":test_cov_path,
+        "RUSTFLAGS": "-C instrument-coverage",
+        "LLVM_PROFILE_FILE": test_cov_path,
     },
 )
 
 # Generate coverage for all the targets
 for fuzz_target in fuzz_targets:
     subprocess.check_call(
-        "cargo fuzz coverage {}".format(fuzz_target), 
-        shell=True, cwd=ROOT,
+        "cargo fuzz coverage {}".format(fuzz_target),
+        shell=True,
+        cwd=ROOT,
     )
 
 # Merge the coverages into an unique file
 subprocess.check_call(
     "{}/llvm-profdata merge -sparse {} -o {}".format(
         llvm_path,
-        " ".join([test_cov_path] + [
-            os.path.join(ROOT, "fuzz", "coverage", fuzz_target, "coverage.profdata")
-            for fuzz_target in fuzz_targets
-        ]),
+        " ".join(
+            [test_cov_path]
+            + [
+                os.path.join(ROOT, "fuzz", "coverage", fuzz_target, "coverage.profdata")
+                for fuzz_target in fuzz_targets
+            ]
+        ),
         final_cov_path,
     ),
-    shell=True, cwd=ROOT,
+    shell=True,
+    cwd=ROOT,
 )
 
 # Create the report!
 subprocess.check_call(
-    "{}/llvm-cov report --Xdemangler=rustfilt --instr-profile={} {} -ignore-filename-regex='.cargo' ".format(
+    (
+        "{}/llvm-cov report --Xdemangler=rustfilt --instr-profile={} {} "
+        "-ignore-filename-regex='.cargo' "
+    ).format(
         llvm_path,
         final_cov_path,
-        " ".join([ # TODO!: add also doc tests binary
-            os.path.join(ROOT, "target", arch, "coverage", arch, "release", fuzz_target)
-            for fuzz_target in fuzz_targets
-        ]),
+        " ".join(
+            [  # TODO!: add also doc tests binary
+                os.path.join(
+                    ROOT, "target", arch, "coverage", arch, "release", fuzz_target
+                )
+                for fuzz_target in fuzz_targets
+            ]
+        ),
     ),
-    shell=True, cwd=ROOT,
+    shell=True,
+    cwd=ROOT,
 )


### PR DESCRIPTION
No semantic changes, with on exception: in code_tables_plot.py an extra
parameter was being passed to the error bar plot but was unused, and spotted as
such by Flake8. It has been removed as part of this commit.
