### PR TITLE
Implement SortedIterator for KMergeIters

### DIFF
--- a/src/utils/sort_pairs.rs
+++ b/src/utils/sort_pairs.rs
@@ -284,6 +284,11 @@ impl<T: Copy, I: Iterator<Item = (usize, usize, T)> + SortedIterator> Iterator
     }
 }
 
+unsafe impl<T: Copy, I: Iterator<Item = (usize, usize, T)> + SortedIterator> SortedIterator
+    for KMergeIters<T, I>
+{
+}
+
 #[cfg(test)]
 #[test]
 pub fn test_push() -> Result<()> {


### PR DESCRIPTION
It allows passing SortPairs (eg. produced by different threads) to KMergeIters to produce a full sorted list