### PR TITLE
Rewrite parallel_compress_sequential_iter using rayon 

### DIFF
--- a/src/bin/recompress.rs
+++ b/src/bin/recompress.rs
@@ -95,7 +95,6 @@ pub fn main() -> Result<()> {
     webgraph::graph::bvgraph::parallel_compress_sequential_iter(
         args.new_basename,
         seq_graph.iter_nodes(),
-        seq_graph.num_nodes(),
         compression_flags,
         args.num_cpus.unwrap_or(rayon::max_num_threads()),
     )?;

--- a/src/bin/transpose.rs
+++ b/src/bin/transpose.rs
@@ -104,7 +104,6 @@ pub fn main() -> Result<()> {
     parallel_compress_sequential_iter(
         args.basename,
         sorted.iter_nodes(),
-        seq_graph.num_nodes(),
         compression_flags,
         args.num_cpus.unwrap_or(rayon::current_num_threads()),
     )

--- a/src/graph/bvgraph/bvgraph_writer_par.rs
+++ b/src/graph/bvgraph/bvgraph_writer_par.rs
@@ -12,17 +12,17 @@ use tempfile::tempdir;
 /// lenght in bits of the produced file
 pub fn parallel_compress_sequential_iter<
     P: AsRef<Path> + Send + Sync,
-    I: Iterator<Item = (usize, J)> + Clone + Send,
+    I: ExactSizeIterator<Item = (usize, J)> + Clone + Send,
     J: Iterator<Item = usize>,
 >(
     basename: P,
     mut iter: I,
-    num_nodes: usize,
     compression_flags: CompFlags,
     num_threads: usize,
 ) -> Result<usize> {
     let basename = basename.as_ref();
     let graph_path = format!("{}.graph", basename.to_string_lossy());
+    let num_nodes = iter.len();
     assert_ne!(num_threads, 0);
     let nodes_per_thread = num_nodes / num_threads;
     let dir = tempdir()?.into_path();

--- a/src/graph/bvgraph/bvgraph_writer_par.rs
+++ b/src/graph/bvgraph/bvgraph_writer_par.rs
@@ -42,28 +42,28 @@ macro_rules! parallel_compress_iter {
                     nodes_per_chunk * (chunk_id + 1),
                 );
 
-                    let writer = <BufferedBitStreamWrite<BE, _>>::new(FileBackend::new(
-                        BufWriter::new(File::create(&file_path).unwrap()),
-                    ));
-                    let codes_writer = <DynamicCodesWriter<BE, _>>::new(writer, cp_flags);
-                    let mut bvcomp = BVComp::new(
-                        codes_writer,
-                        cp_flags.compression_window,
-                        cp_flags.min_interval_length,
-                        cp_flags.max_ref_count,
-                        nodes_per_chunk * chunk_id,
-                    );
+                let writer = <BufferedBitStreamWrite<BE, _>>::new(FileBackend::new(
+                    BufWriter::new(File::create(&file_path).unwrap()),
+                ));
+                let codes_writer = <DynamicCodesWriter<BE, _>>::new(writer, cp_flags);
+                let mut bvcomp = BVComp::new(
+                    codes_writer,
+                    cp_flags.compression_window,
+                    cp_flags.min_interval_length,
+                    cp_flags.max_ref_count,
+                    nodes_per_chunk * chunk_id,
+                );
 
-                    let written_bits = bvcomp.extend(chunk_iter.into_iter()).unwrap();
+                let written_bits = bvcomp.extend(chunk_iter.into_iter()).unwrap();
 
-                    log::info!(
-                        "Finished Compression chunk {} and wrote {} bits bits [{}, {})",
-                        chunk_id,
-                        written_bits,
-                        nodes_per_chunk * chunk_id,
-                        nodes_per_chunk * (chunk_id + 1),
-                    );
-                    (chunk_id, written_bits, bvcomp.arcs)
+                log::info!(
+                    "Finished Compression chunk {} and wrote {} bits bits [{}, {})",
+                    chunk_id,
+                    written_bits,
+                    nodes_per_chunk * chunk_id,
+                    nodes_per_chunk * (chunk_id + 1),
+                );
+                (chunk_id, written_bits, bvcomp.arcs)
             })
             .collect();
 

--- a/src/utils/coo_to_graph.rs
+++ b/src/utils/coo_to_graph.rs
@@ -77,6 +77,14 @@ impl<'a, I: Iterator<Item = (usize, usize)>> Iterator for SortedNodePermutedIter
     }
 }
 
+impl<'a, I: Iterator<Item = (usize, usize)>> ExactSizeIterator
+    for SortedNodePermutedIterator<'a, I>
+{
+    fn len(&self) -> usize {
+        self.num_nodes
+    }
+}
+
 #[derive(Debug, Clone)]
 /// Iter until we found a triple with src different than curr_node
 pub struct SortedSequentialPermutedIterator<'a, I: Iterator<Item = (usize, usize)>> {

--- a/tests/test_par_bvcomp.rs
+++ b/tests/test_par_bvcomp.rs
@@ -14,17 +14,17 @@ fn test_par_bvcomp() -> Result<()> {
 
     // load the graph
     let graph = webgraph::graph::bvgraph::load_seq("tests/data/cnr-2000")?;
-    for thread_num in 1..10 {
-        log::info!("Testing with {} threads", thread_num);
+    for chunk_num in 1..10 {
+        log::info!("Testing with {} chunks", chunk_num);
         // create a threadpool and make the compression use it, this way
-        // we can test with different number of threads
+        // we can test with different number of chunks
         let start = std::time::Instant::now();
         // recompress the graph in parallel
         webgraph::graph::bvgraph::parallel_compress_sequential_iter(
             tmp_basename,
             graph.iter_nodes(),
             comp_flags.clone(),
-            thread_num,
+            chunk_num,
         )
         .unwrap();
         log::info!("The compression took: {}s", start.elapsed().as_secs_f64());

--- a/tests/test_par_bvcomp.rs
+++ b/tests/test_par_bvcomp.rs
@@ -23,7 +23,6 @@ fn test_par_bvcomp() -> Result<()> {
         webgraph::graph::bvgraph::parallel_compress_sequential_iter(
             tmp_basename,
             graph.iter_nodes(),
-            graph.num_nodes(),
             comp_flags.clone(),
             thread_num,
         )

--- a/tests/transpose.rs
+++ b/tests/transpose.rs
@@ -23,11 +23,11 @@ fn test_transpose() -> Result<()> {
     parallel_compress_sequential_iter(
         TRANSPOSED_PATH,
         transposed.iter_nodes(),
-        num_nodes,
         compression_flags,
         rayon::current_num_threads(),
     )?;
     // check it
+    assert_eq!(transposed.iter_nodes().len(), num_nodes);
     let transposed_graph = webgraph::graph::bvgraph::load_seq(TRANSPOSED_PATH)?;
     assert_eq!(transposed_graph.num_nodes(), num_nodes);
 
@@ -42,11 +42,11 @@ fn test_transpose() -> Result<()> {
     parallel_compress_sequential_iter(
         RE_TRANSPOSED_PATH,
         retransposed.iter_nodes(),
-        num_nodes,
         compression_flags,
         rayon::current_num_threads(),
     )?;
     // check it
+    assert_eq!(retransposed.iter_nodes().len(), num_nodes);
     let retransposed_graph = webgraph::graph::bvgraph::load_seq(RE_TRANSPOSED_PATH)?;
     assert_eq!(retransposed_graph.num_nodes(), num_nodes);
 


### PR DESCRIPTION
Motivations:

* allow ParallelIterator input instead of forcing callers to
  sequentialize their node iterators
* fix unsoundness regarding the behavior of `Clone` + `Iterator`: the
  code previously assumed cloning an iterator would split it into
  chunks, but this is not guaranteed (items could be duplicates or
  interspersed).
* remove manual thread management
* avoid special-handling for the first and last chunks.

The changeset of this pull request may be hard to read because a large part of the code didn't change except for their indent level or variable names. I recommend reading commit-per-commit.

This alters the way work is distributed: rayon is now in charge of picking the number of threads and how to distribute chunks across threads. On my machine, the timings (i7-8700, 12 threads), this has no impact on the timings written by `test_par_comp`.

<details>
<summary>
Regarding the use of a macro, I wish I could do this purely within the type system, but `<ExactSizeIterator + Itertools>::chunks` and `IndexedParallelIterator::chunks` are surprisingly hard to unify.
</summary>

I went as far as this, and it still didn't compile:

```rust
pub trait MaybeParallelChunks {
    type Item;
}

impl<'a, I: 'a, Iter: Iterator<Item = I>> MaybeParallelChunks for itertools::Chunks<'a, Iter> {
    type Item = I;
}

pub trait IntoMaybeParallelChunks<Item> {
    type Chunk: IntoIterator<Item = Item>;
    type Chunks<'a>: MaybeParallelChunks<Item = Item> + 'a
    where
        Self: 'a;

    fn my_into_iter<'a>(self) -> Self::Chunks<'a>
    where
        Self: 'a;
}

impl<'b, Item: 'b, Iter: Iterator<Item = Item> + 'b> IntoMaybeParallelChunks<Item>
    for &'b itertools::IntoChunks<Iter>
{
    type Chunk = Vec<Item>;
    type Chunks<'a> = itertools::Chunks<'a, Iter> where 'b: 'a;

    fn my_into_iter<'a>(self) -> Self::Chunks<'a>
    where
        'b: 'a,
    {
        IntoIterator::into_iter(self)
    }
}

use std::borrow::Borrow;
use std::ops::Deref;

pub trait Chunkable {
    type Item;
    type IntoChunks where for<'a> Self::IntoChunks: Borrow<Self::IntoChunksRef<'a>>;
    type IntoChunksRef<'a>: IntoMaybeParallelChunks<Self::Item> + 'a
    where
        Self: 'a,
        Self::Item: 'a;

    fn chunks(self, size: usize) -> Self::IntoChunks where for<'a> Self::IntoChunks: Borrow<Self::IntoChunksRef<'a>>;
}

impl<Item, Iter: ExactSizeIterator<Item = Item>> Chunkable for Iter {
    type Item = Item;
    type IntoChunks = itertools::IntoChunks<Iter>;
    type IntoChunksRef<'a> = &'a itertools::IntoChunks<Iter> where Iter: 'a;

    fn chunks(self, size: usize) -> itertools::IntoChunks<Iter> {
        self.chunks(size)
    }
}
```
</details>