### PR TITLE
layered_label_propagation: Simplify type annotation

### DIFF
--- a/src/algorithms/llp.rs
+++ b/src/algorithms/llp.rs
@@ -30,8 +30,7 @@ pub fn layered_label_propagation<G>(
     seed: u64,
 ) -> Result<Box<[usize]>>
 where
-    G: RandomAccessGraph,
-    for<'a> &'a G: Send + Sync,
+    G: RandomAccessGraph + Sync,
 {
     let num_cpus = num_cpus.unwrap_or_else(num_cpus::get);
     let num_nodes = graph.num_nodes();


### PR DESCRIPTION
According to https://doc.rust-lang.org/std/marker/trait.Sync.html :

1. "T is Sync if and only if &T is Send"
2. "&T and &mut T are Sync if and only if T is Sync"

therefore:

* `for<'a> &'a G: Send + Sync` implies `for<'a> &'a G: Send`, which implies `G: Sync` (because of 1)
* `G: Sync` implies "&T and &mut T are Sync" (according to 2), which implies `for<'a> &'a G: Sync`

therefore, `for<'a> &'a G: Send + Sync` is equivalent to `G: Sync`.