### PR TITLE
Allow calling LLP with an uninitialized slice

### DIFF
--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -1,5 +1,5 @@
 mod llp;
-pub use llp::layered_label_propagation;
+pub use llp::{layered_label_propagation, layered_label_propagation_uninit};
 
 mod bfs_order;
 pub use bfs_order::bfs_order;

--- a/src/bin/llp.rs
+++ b/src/bin/llp.rs
@@ -56,11 +56,11 @@ pub fn main() -> Result<()> {
     // load the graph
     let graph = webgraph::graph::bvgraph::load(&args.basename)?;
 
-    let mut perm = vec![0; graph.num_nodes()];
+    let mut perm = Vec::with_capacity(graph.num_nodes());
     // compute the LLP
-    let labels = layered_label_propagation(
+    let (labels, perm) = layered_label_propagation_uninit(
         &graph,
-        &mut perm,
+        perm.spare_capacity_mut(),
         args.gamma,
         args.num_cpus,
         args.max_iters,


### PR DESCRIPTION
The API is a little more clunky to use in order for the caller to get `&mut[usize]` without transmuting themselves, so this adds a new function that callers can opt into.