### PR TITLE
LLP: Prevent race condition when checking can_change

### DIFF
--- a/src/algorithms/llp.rs
+++ b/src/algorithms/llp.rs
@@ -101,12 +101,12 @@ where
                         let chunk = &perm[next_pos..end_pos];
 
                         for &node in chunk {
-                            // if the node can't change we can skip it
-                            if !can_change[node].load(Ordering::Relaxed) {
+                            // if the node can't change we can skip it; if it can then
+                            // we mark it as un-changeable for now and we'll unset later
+                            // it if it can
+                            if !can_change[node].fetch_and(false, Ordering::Relaxed) {
                                 continue;
                             }
-                            // set that the node can't change by default and we'll unset later it if it can
-                            can_change[node].store(false, Ordering::Relaxed);
 
                             let successors = graph.successors(node);
                             if successors.len() == 0 {


### PR DESCRIPTION
I don't really understand how this function works yet, and I don't have any evidence this is actually an issue, so please double-check this.

It seems to me that two threads could be processing it at the same time, because `can_change[node]` was not checked and set atomically. Is that right?

