### PR TITLE
bin/llp: Allow negative --gamma values

### DIFF
--- a/src/bin/llp.rs
+++ b/src/bin/llp.rs
@@ -26,7 +26,7 @@ struct Args {
     /// at the start of each iteration
     chunk_size: usize,
 
-    #[arg(short, long, use_value_delimiter = true, value_delimiter = ',', default_values_t = vec!["-0".to_string(), "-1".to_string(), "-2".to_string(), "-3".to_string(), "-4".to_string(), "-5".to_string(), "-6".to_string(), "-7".to_string(), "-8".to_string(), "-9".to_string(), "-10".to_string(), "0-0".to_string()])]
+    #[arg(short, long, allow_hyphen_values = true, use_value_delimiter = true, value_delimiter = ',', default_values_t = vec!["-0".to_string(), "-1".to_string(), "-2".to_string(), "-3".to_string(), "-4".to_string(), "-5".to_string(), "-6".to_string(), "-7".to_string(), "-8".to_string(), "-9".to_string(), "-10".to_string(), "0-0".to_string()])]
     /// The gammas to use in LLP, separated by commas. The format is given by a integer
     /// numerator (if missing, assumed to be one),
     /// a dash, and then a power-of-two exponent for the denominator. For example, -2 is 1/4, and 0-0 is 0.


### PR DESCRIPTION
without this patch:

```
$ cargo run --bin llp /tmp/bvgraph perm --gammas "-0,-1,-2,-3,-4"
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/llp /tmp/bvgraph perm --gammas -0,-1,-2,-3,-4`
error: unexpected argument '-0' found

  tip: to pass '-0' as a value, use '-- -0'
```