### PR TITLE
Migrate test cases with verbose stderr logging to env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "epserde"
 version = "0.1.0"
 source = "git+https://github.com/vigna/epserde-rs#cc466e23da207191b11f3e8ff1e54d9973c0117e"
@@ -758,6 +771,12 @@ checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -1570,6 +1589,7 @@ dependencies = [
  "clap",
  "dsi-bitstream",
  "dsi-progress-logger",
+ "env_logger",
  "epserde",
  "itertools",
  "java-properties",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ bindgen = "0.65.1"
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = ["small_rng"] }
+env_logger = "0.9.0"
 
 [profile.release] # Used for the examples
 opt-level = 3             # like --release

--- a/tests/test_bvcomp.rs
+++ b/tests/test_bvcomp.rs
@@ -22,14 +22,14 @@ use webgraph::{
     utils::MmapBackend,
 };
 
+fn logger_init() {
+    env_logger::builder().is_test(true).try_init().unwrap();
+}
+
 #[cfg_attr(feature = "slow_tests", test)]
 #[cfg_attr(not(feature = "slow_tests"), allow(dead_code))]
 fn test_bvcomp_slow() -> Result<()> {
-    stderrlog::new()
-        .verbosity(2)
-        .timestamp(stderrlog::Timestamp::Second)
-        .init()
-        .unwrap();
+    logger_init();
 
     let tmp_file = NamedTempFile::new()?;
     let tmp_path = tmp_file.path();

--- a/tests/test_par_bvcomp.rs
+++ b/tests/test_par_bvcomp.rs
@@ -2,13 +2,13 @@ use anyhow::Result;
 use dsi_progress_logger::ProgressLogger;
 use webgraph::prelude::*;
 
+fn logger_init() {
+    env_logger::builder().is_test(true).try_init().unwrap();
+}
+
 #[test]
 fn test_par_bvcomp() -> Result<()> {
-    stderrlog::new()
-        .verbosity(2)
-        .timestamp(stderrlog::Timestamp::Second)
-        .init()
-        .unwrap();
+    logger_init();
     let comp_flags = CompFlags::default();
     let tmp_basename = "tests/data/cnr-2000-par";
 

--- a/tests/transpose.rs
+++ b/tests/transpose.rs
@@ -1,17 +1,17 @@
 use anyhow::Result;
 use webgraph::prelude::*;
 
+fn logger_init() {
+    env_logger::builder().is_test(true).try_init().unwrap();
+}
+
 #[test]
 fn test_transpose() -> Result<()> {
     const TRANSPOSED_PATH: &str = "tests/data/cnr-2000-transposed";
     const RE_TRANSPOSED_PATH: &str = "tests/data/cnr-2000-transposed-transposed";
     const BATCH_SIZE: usize = 100_000;
 
-    stderrlog::new()
-        .verbosity(2)
-        .timestamp(stderrlog::Timestamp::Second)
-        .init()
-        .unwrap();
+    logger_init();
 
     let compression_flags = CompFlags::default();
 


### PR DESCRIPTION
Tests concerned: test_bvcomp, test_par_bvcomp, transpose

Rationale: all these tests had very verbose logging (e.g., what each thread is doing) on stderr by default, completely dominating the amount of test output. With this change they log to the env_logger instead, which by default is silent. In case of test failure, the test can be rerun with output with something like:

  RUST_LOG=info cargo t -- --nocapture