### PR TITLE
bvgraph_writer: Take ownership of iterators before consuming them

### DIFF
--- a/src/bin/perm.rs
+++ b/src/bin/perm.rs
@@ -76,7 +76,7 @@ fn permute(
         arc_list_graph::NodeIterator<std::iter::Map<KMergeIters<_>, _>>,
     >(
         args.dest,
-        &mut g.iter(),
+        g.iter(),
         g.num_nodes(),
         CompFlags::default(),
         args.num_cpus.unwrap_or(num_cpus::get()),

--- a/src/bin/recompress.rs
+++ b/src/bin/recompress.rs
@@ -97,10 +97,10 @@ pub fn main() -> Result<()> {
     };
 
     let seq_graph = webgraph::graph::bvgraph::load_seq(&args.basename)?;
-    let mut iter = seq_graph.iter();
+    let iter = seq_graph.iter();
     webgraph::graph::bvgraph::parallel_compress_sequential_iter::<WebgraphSequentialIter<_>>(
         args.new_basename,
-        &mut iter,
+        iter,
         seq_graph.num_nodes(),
         compression_flags,
         args.num_cpus.unwrap_or(rayon::max_num_threads()),

--- a/src/bin/transpose.rs
+++ b/src/bin/transpose.rs
@@ -111,7 +111,7 @@ pub fn main() -> Result<()> {
         arc_list_graph::NodeIterator<std::iter::Map<KMergeIters<_>, _>>,
     >(
         args.basename,
-        &mut sorted.iter(),
+        sorted.iter(),
         sorted.num_nodes(),
         compression_flags,
         args.num_cpus.unwrap_or(rayon::current_num_threads()),

--- a/src/graph/bvgraph/bvgraph_writer.rs
+++ b/src/graph/bvgraph/bvgraph_writer.rs
@@ -432,7 +432,7 @@ impl<WGCW: BVGraphCodesWriter> BVComp<WGCW> {
     /// WARNING: presently type inference does not work very well with this method:
     /// you have to specify the type of `L` explicitly, sometimes just
     /// partially---your mileage may vary.
-    pub fn extend<L>(&mut self, iter_nodes: &mut L) -> Result<usize>
+    pub fn extend<L>(&mut self, mut iter_nodes: L) -> Result<usize>
     where
         L: LendingIterator,
         for<'next> Item<'next, L>: Tuple2<_0 = usize>,
@@ -449,8 +449,8 @@ impl<WGCW: BVGraphCodesWriter> BVComp<WGCW> {
 
     /// Calls [`BVComp::extend`] with argument `graph.iter_nodes()`.
     pub fn extend_graph<S: SequentialGraph>(&mut self, graph: &S) -> Result<usize> {
-        let mut iter = graph.iter();
-        self.extend::<<S as SequentialGraph>::Iterator<'_>>(&mut iter)
+        let iter = graph.iter();
+        self.extend::<<S as SequentialGraph>::Iterator<'_>>(iter)
     }
 
     /// Consume the compressor and flush the inner writer.

--- a/src/graph/bvgraph/bvgraph_writer_par.rs
+++ b/src/graph/bvgraph/bvgraph_writer_par.rs
@@ -94,7 +94,7 @@ pub fn compress_sequential_iter<
 /// lenght in bits of the produced file
 pub fn parallel_compress_sequential_iter<L: LendingIterator + Clone + Send>(
     basename: impl AsRef<Path> + Send + Sync,
-    iter: &mut L,
+    mut iter: L,
     num_nodes: usize,
     compression_flags: CompFlags,
     num_threads: usize,
@@ -153,7 +153,7 @@ where
                     nodes_per_thread * (thread_id + 1),
                 );
                 // Spawn the thread
-                let mut thread_iter = iter.clone();
+                let thread_iter = iter.clone();
                 let handle = s.spawn(move || {
                     log::info!("Thread {} started", thread_id,);
                     let writer = <BufBitWriter<BE, _>>::new(WordAdapter::new(BufWriter::new(
@@ -167,7 +167,7 @@ where
                         cp_flags.max_ref_count,
                         nodes_per_thread * thread_id,
                     );
-                    let written_bits = bvcomp.extend::<L>(&mut thread_iter).unwrap();
+                    let written_bits = bvcomp.extend::<L>(thread_iter).unwrap();
                     log::info!(
                         "Finished Compression thread {} and wrote {} bits bits [{}, {})",
                         thread_id,

--- a/tests/test_par_bvcomp.rs
+++ b/tests/test_par_bvcomp.rs
@@ -40,7 +40,7 @@ fn test_par_bvcomp() -> Result<()> {
             >,
         >(
             tmp_basename,
-            &mut graph.iter(),
+            graph.iter(),
             graph.num_nodes(),
             comp_flags,
             thread_num,

--- a/tests/transpose.rs
+++ b/tests/transpose.rs
@@ -34,7 +34,7 @@ fn test_transpose() -> Result<()> {
         >,
     >(
         TRANSPOSED_PATH,
-        &mut transposed.iter(),
+        transposed.iter(),
         transposed.num_nodes(),
         compression_flags,
         rayon::current_num_threads(),
@@ -63,7 +63,7 @@ fn test_transpose() -> Result<()> {
         >,
     >(
         RE_TRANSPOSED_PATH,
-        &mut retransposed.iter(),
+        retransposed.iter(),
         retransposed.num_nodes(),
         compression_flags,
         rayon::current_num_threads(),


### PR DESCRIPTION
It does not functionally change anything, but it is more intuitive as the iterators are fully consumed by these functions, so the caller cannot do anything with them afterward either way