### PR TITLE
Bump minimum dsi-bitstream version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bitvec = { version = "1.0.1", features = ["atomic"] }
 num_cpus = "1.16.0"
 epserde = "0.3.1"
 sux = "0.1.3"
-dsi-bitstream = "0.2.0"
+dsi-bitstream = "0.2.2"
 clap = { version = "4.4.18", features = ["derive"] }
 dsi-progress-logger = "0.2.2"
 log = "0.4.20"


### PR DESCRIPTION
To fix this error:

```
error[E0277]: `dyn std::error::Error` cannot be sent between threads safely
   --> src/graphs/bvgraph/comp/util.rs:332:74
    |
332 |                 result_writer.copy_from(&mut reader, bits_to_copy as u64)?;
    |                                                                          ^ `dyn std::error::Error` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `dyn std::error::Error`
    = help: the following other types implement trait `std::ops::FromResidual<R>`:
              <Result<T, F> as std::ops::FromResidual<Yeet<E>>>
              <Result<T, F> as std::ops::FromResidual<Result<Infallible, E>>>
    = note: required for `std::ptr::Unique<dyn std::error::Error>` to implement `Send`
note: required because it appears within the type `Box<dyn Error>`
   --> /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:195:12
    = note: required for `anyhow::Error` to implement `From<Box<dyn std::error::Error>>`
    = note: required for `Result<usize, anyhow::Error>` to implement `std::ops::FromResidual<Result<Infallible, Box<dyn std::error::Error>>>`

error[E0277]: `dyn std::error::Error` cannot be shared between threads safely
   --> src/graphs/bvgraph/comp/util.rs:332:74
    |
332 |                 result_writer.copy_from(&mut reader, bits_to_copy as u64)?;
    |                                                                          ^ `dyn std::error::Error` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `dyn std::error::Error`
    = help: the following other types implement trait `std::ops::FromResidual<R>`:
              <Result<T, F> as std::ops::FromResidual<Yeet<E>>>
              <Result<T, F> as std::ops::FromResidual<Result<Infallible, E>>>
    = note: required for `std::ptr::Unique<dyn std::error::Error>` to implement `Sync`
note: required because it appears within the type `Box<dyn Error>`
   --> /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:195:12
    = note: required for `anyhow::Error` to implement `From<Box<dyn std::error::Error>>`
    = note: required for `Result<usize, anyhow::Error>` to implement `std::ops::FromResidual<Result<Infallible, Box<dyn std::error::Error>>>`

error[E0277]: the size for values of type `dyn std::error::Error` cannot be known at compilation time
   --> src/graphs/bvgraph/comp/util.rs:332:74
    |
332 |                 result_writer.copy_from(&mut reader, bits_to_copy as u64)?;
    |                                                                          ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn std::error::Error`
    = help: the following other types implement trait `std::ops::FromResidual<R>`:
              <Result<T, F> as std::ops::FromResidual<Yeet<E>>>
              <Result<T, F> as std::ops::FromResidual<Result<Infallible, E>>>
    = note: required for `Box<dyn std::error::Error>` to implement `std::error::Error`
    = note: required for `anyhow::Error` to implement `From<Box<dyn std::error::Error>>`
    = note: required for `Result<usize, anyhow::Error>` to implement `std::ops::FromResidual<Result<Infallible, Box<dyn std::error::Error>>>`
```