### PR TITLE
build/{ef,offsets}: Import changes from swh-graph

### DIFF
--- a/src/cli/build/ef.rs
+++ b/src/cli/build/ef.rs
@@ -21,13 +21,13 @@ pub const COMMAND_NAME: &str = "ef";
 
 #[derive(Args, Debug)]
 #[command(about = "Builds the .ef file for a graph.", long_about = None)]
-struct CliArgs {
+pub struct CliArgs {
     /// The basename of the graph.
-    basename: PathBuf,
+    pub basename: PathBuf,
     /// The number of elements to be inserted in the Elias-Fano
     /// starting from a label offset file. It is usually one more than
     /// the number of nodes in the graph.
-    n: Option<usize>,
+    pub n: Option<usize>,
 }
 
 pub fn cli(command: Command) -> Command {
@@ -52,7 +52,7 @@ pub fn main(submatches: &ArgMatches) -> Result<()> {
     }
 }
 
-fn build_eliasfano<E: Endianness + 'static>(args: CliArgs) -> Result<()>
+pub fn build_eliasfano<E: Endianness + 'static>(args: CliArgs) -> Result<()>
 where
     for<'a> BufBitReader<E, MemWordReader<u32, &'a [u32]>>: CodeRead<E> + BitSeek,
 {

--- a/src/cli/build/offsets.rs
+++ b/src/cli/build/offsets.rs
@@ -23,7 +23,7 @@ pub const COMMAND_NAME: &str = "offsets";
 
 pub struct CliArgs {
     /// The basename of the graph.
-    basename: PathBuf,
+    pub basename: PathBuf,
 }
 
 pub fn cli(command: Command) -> Command {
@@ -48,7 +48,7 @@ pub fn main(submatches: &ArgMatches) -> Result<()> {
     }
 }
 
-fn build_offsets<E: Endianness + 'static>(args: CliArgs) -> Result<()>
+pub fn build_offsets<E: Endianness + 'static>(args: CliArgs) -> Result<()>
 where
     for<'a> BufBitReader<E, MemWordReader<u32, &'a [u32]>>: CodeRead<E> + BitSeek,
     for<'a> BufBitReader<E, WordAdapter<u32, BufReader<File>>>: CodeRead<E> + BitSeek,

--- a/src/cli/build/offsets.rs
+++ b/src/cli/build/offsets.rs
@@ -13,6 +13,7 @@ use dsi_progress_logger::*;
 use std::{
     fs::File,
     io::{BufReader, BufWriter},
+    path::PathBuf,
 };
 
 pub const COMMAND_NAME: &str = "offsets";
@@ -22,7 +23,7 @@ pub const COMMAND_NAME: &str = "offsets";
 
 pub struct CliArgs {
     /// The basename of the graph.
-    basename: String,
+    basename: PathBuf,
 }
 
 pub fn cli(command: Command) -> Command {
@@ -57,7 +58,8 @@ where
         .endianness::<E>()
         .load()?;
     // Create the offsets file
-    let file = std::fs::File::create(format!("{}.offsets", args.basename))?;
+    let target = suffix_path(&args.basename, ".offsets");
+    let file = std::fs::File::create(&target)?;
     // create a bit writer on the file
     let mut writer = <BufBitWriter<BE, _>>::new(<WordAdapter<u64, _>>::new(
         BufWriter::with_capacity(1 << 20, file),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
  */
+
+use std::path::{Path, PathBuf};
+
 use rand::Rng;
 
 /// Bijective mapping from isize to u64 as defined in <https://github.com/vigna/dsiutils/blob/master/src/it/unimi/dsi/bits/Fast.java>
@@ -46,6 +49,24 @@ pub fn temp_dir<P: AsRef<std::path::Path>>(base: P) -> String {
         }
         base.pop();
     }
+}
+
+/// Appends a string to a path
+///
+/// ```
+/// # use std::path::{Path, PathBuf};
+/// # use webgraph::utils::suffix_path;
+///
+/// assert_eq!(
+///     suffix_path(Path::new("/tmp/graph"), "-transposed"),
+///     Path::new("/tmp/graph-transposed").to_owned()
+/// );
+/// ```
+#[inline(always)]
+pub fn suffix_path<P: AsRef<Path>, S: AsRef<std::ffi::OsStr>>(path: P, suffix: S) -> PathBuf {
+    let mut path = path.as_ref().as_os_str().to_owned();
+    path.push(suffix);
+    path.into()
 }
 
 mod circular_buffer;


### PR DESCRIPTION
I copy-pasted these functions in swh-graph so I could use them there, and made two  changes:

* Represent paths as PathBuf instead of String
* Add context to errors

This PR imports these changes, and makes the two functions public so I can call them from swh-graph without copying the code or going building an `ArgsMatch` value.