### PR TITLE
CLI: rename merge_perms command to merge-perms

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -19,7 +19,7 @@ $WEBGRAPH build dcf $GRAPH-simplified
 # Step5: Run LLP to get the final permutation
 $WEBGRAPH llp $GRAPH-simplified $GRAPH.llp
 # Step6: Merge the two permutations
-$WEBGRAPH merge_perms $GRAPH.merged_perm $GRAPH.bfs $GRAPH.llp
+$WEBGRAPH merge-perms $GRAPH.merged_perm $GRAPH.bfs $GRAPH.llp
 # Step7: Apply both permutations to the original graph
 $WEBGRAPH recompress $GRAPH $GRAPH-final --permutation $GRAPH.merged_perm
 # Step8: Create the final Elias Fano

--- a/src/cli/merge_perms.rs
+++ b/src/cli/merge_perms.rs
@@ -14,7 +14,7 @@ use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 use sux::traits::BitFieldSlice;
 
-pub const COMMAND_NAME: &str = "merge_perms";
+pub const COMMAND_NAME: &str = "merge-perms";
 
 #[derive(Args, Debug)]
 #[command(about = "Merge multiple permutations into a single one", long_about = None)]


### PR DESCRIPTION
rationale: it was the only command with underscore instead of dash