### PR TITLE
Make all CLI implementations public

### DIFF
--- a/src/cli/ascii_convert.rs
+++ b/src/cli/ascii_convert.rs
@@ -44,7 +44,7 @@ pub fn main(submatches: &ArgMatches) -> Result<()> {
     }
 }
 
-fn ascii_convert<E: Endianness + 'static>(basename: &str) -> Result<()>
+pub fn ascii_convert<E: Endianness + 'static>(basename: &str) -> Result<()>
 where
     for<'a> BufBitReader<E, MemWordReader<u32, &'a [u32]>>: CodeRead<E> + BitSeek,
 {

--- a/src/cli/bfs.rs
+++ b/src/cli/bfs.rs
@@ -17,7 +17,7 @@ pub const COMMAND_NAME: &str = "bfs";
 
 #[derive(Args, Debug)]
 #[command(about = "Compute a permutation with the BFS order", long_about = None)]
-struct CliArgs {
+pub struct CliArgs {
     /// The basename of the graph.
     basename: PathBuf,
 
@@ -41,17 +41,17 @@ pub fn main(submatches: &ArgMatches) -> Result<()> {
             feature = "be_bins",
             not(any(feature = "be_bins", feature = "le_bins"))
         ))]
-        BE::NAME => bfs_impl::<BE>(args),
+        BE::NAME => bfs::<BE>(args),
         #[cfg(any(
             feature = "le_bins",
             not(any(feature = "be_bins", feature = "le_bins"))
         ))]
-        LE::NAME => bfs_impl::<LE>(args),
+        LE::NAME => bfs::<LE>(args),
         e => panic!("Unknown endianness: {}", e),
     }
 }
 
-fn bfs_impl<E: Endianness + 'static + Send + Sync>(args: CliArgs) -> Result<()>
+pub fn bfs<E: Endianness + 'static + Send + Sync>(args: CliArgs) -> Result<()>
 where
     for<'a> BufBitReader<E, MemWordReader<u32, &'a [u32]>>: CodeRead<E> + BitSeek,
 {

--- a/src/cli/check_ef.rs
+++ b/src/cli/check_ef.rs
@@ -24,7 +24,7 @@ pub const COMMAND_NAME: &str = "check-ef";
 
 #[derive(Args, Debug)]
 #[command(about = "Check that the '.ef' file (and `.offsets` if present) is coherent with the graph.", long_about = None)]
-struct CliArgs {
+pub struct CliArgs {
     /// The basename of the graph.
     basename: PathBuf,
 }
@@ -34,8 +34,10 @@ pub fn cli(command: Command) -> Command {
 }
 
 pub fn main(submatches: &ArgMatches) -> Result<()> {
-    let args = CliArgs::from_arg_matches(submatches)?;
+    check_ef(CliArgs::from_arg_matches(submatches)?)
+}
 
+pub fn check_ef(args: CliArgs) -> Result<()> {
     let properties_path = args.basename.with_extension(PROPERTIES_EXTENSION);
     let f = File::open(&properties_path).with_context(|| {
         format!(

--- a/src/cli/from_csv.rs
+++ b/src/cli/from_csv.rs
@@ -22,7 +22,7 @@ pub const COMMAND_NAME: &str = "from-csv";
 
 #[derive(Args, Debug)]
 #[command(about = "Compress a CSV graph from stdin into webgraph. This does not support any form of escaping.", long_about = None)]
-struct CliArgs {
+pub struct CliArgs {
     /// The basename of the dst.
     basename: PathBuf,
 
@@ -52,7 +52,10 @@ pub fn cli(command: Command) -> Command {
 }
 
 pub fn main(submatches: &ArgMatches) -> Result<()> {
-    let args = CliArgs::from_arg_matches(submatches)?;
+    from_csv(CliArgs::from_arg_matches(submatches)?)
+}
+
+pub fn from_csv(args: CliArgs) -> Result<()> {
     let dir = Builder::new().prefix("FromCsvPairs").tempdir()?;
 
     let mut group_by = SortPairs::new(args.pa.batch_size, dir)?;

--- a/src/cli/llp.rs
+++ b/src/cli/llp.rs
@@ -26,7 +26,7 @@ pub const COMMAND_NAME: &str = "llp";
 
 #[derive(Args, Debug)]
 #[command(about = "Performs an LLP round.", long_about = None)]
-struct CliArgs {
+pub struct CliArgs {
     /// The basename of the graph.
     basename: PathBuf,
 
@@ -97,17 +97,17 @@ pub fn main(submatches: &ArgMatches) -> Result<()> {
             feature = "be_bins",
             not(any(feature = "be_bins", feature = "le_bins"))
         ))]
-        BE::NAME => llp_impl::<BE>(args),
+        BE::NAME => llp::<BE>(args),
         #[cfg(any(
             feature = "le_bins",
             not(any(feature = "be_bins", feature = "le_bins"))
         ))]
-        LE::NAME => llp_impl::<LE>(args),
+        LE::NAME => llp::<LE>(args),
         e => panic!("Unknown endianness: {}", e),
     }
 }
 
-fn llp_impl<E: Endianness + 'static + Send + Sync>(args: CliArgs) -> Result<()>
+pub fn llp<E: Endianness + 'static + Send + Sync>(args: CliArgs) -> Result<()>
 where
     for<'a> BufBitReader<E, MemWordReader<u32, &'a [u32]>>: CodeRead<E> + BitSeek,
 {

--- a/src/cli/merge_perms.rs
+++ b/src/cli/merge_perms.rs
@@ -18,7 +18,7 @@ pub const COMMAND_NAME: &str = "merge-perms";
 
 #[derive(Args, Debug)]
 #[command(about = "Merge multiple permutations into a single one", long_about = None)]
-struct CliArgs {
+pub struct CliArgs {
     /// The basename of the graph.
     result_path: PathBuf,
 
@@ -35,7 +35,10 @@ pub fn cli(command: Command) -> Command {
 }
 
 pub fn main(submatches: &ArgMatches) -> Result<()> {
-    let args = CliArgs::from_arg_matches(submatches)?;
+    merge_perms(CliArgs::from_arg_matches(submatches)?)
+}
+
+pub fn merge_perms(args: CliArgs) -> Result<()> {
     let start = std::time::Instant::now();
 
     if args.epserde {

--- a/src/cli/optimize_codes.rs
+++ b/src/cli/optimize_codes.rs
@@ -17,7 +17,7 @@ pub const COMMAND_NAME: &str = "optimize-codes";
 
 #[derive(Args, Debug)]
 #[command(about = "Reads a graph and suggests the best codes to use.", long_about = None)]
-struct CliArgs {
+pub struct CliArgs {
     /// The basename of the graph.
     basename: PathBuf,
 }
@@ -44,7 +44,7 @@ pub fn main(submatches: &ArgMatches) -> Result<()> {
     }
 }
 
-fn optimize_codes<E: Endianness + 'static>(args: CliArgs) -> Result<()>
+pub fn optimize_codes<E: Endianness + 'static>(args: CliArgs) -> Result<()>
 where
     for<'a> BufBitReader<E, MemWordReader<u32, &'a [u32]>>: CodeRead<E> + BitSeek,
 {

--- a/src/cli/pad.rs
+++ b/src/cli/pad.rs
@@ -18,7 +18,7 @@ use crate::graphs::GRAPH_EXTENSION;
 
 pub const COMMAND_NAME: &str = "pad";
 
-fn pad(path: impl AsRef<Path>, block_size: usize) -> Result<()> {
+pub fn pad(path: impl AsRef<Path>, block_size: usize) -> Result<()> {
     let path = path.as_ref();
     let file_len = path
         .metadata()

--- a/src/cli/rand_perm.rs
+++ b/src/cli/rand_perm.rs
@@ -18,7 +18,7 @@ pub const COMMAND_NAME: &str = "rand-perm";
 
 #[derive(Args, Debug)]
 #[command(about = "Create a random permutation for a given graph.", long_about = None)]
-struct CliArgs {
+pub struct CliArgs {
     /// The basename of the graph.
     source: PathBuf,
     /// The permutation.
@@ -51,7 +51,7 @@ pub fn main(submatches: &ArgMatches) -> Result<()> {
     }
 }
 
-fn rand_perm<E: Endianness + 'static>(args: CliArgs) -> Result<()>
+pub fn rand_perm<E: Endianness + 'static>(args: CliArgs) -> Result<()>
 where
     for<'a> BufBitReader<E, MemWordReader<u32, &'a [u32]>>: CodeRead<E> + BitSeek,
 {

--- a/src/cli/recompress.rs
+++ b/src/cli/recompress.rs
@@ -18,7 +18,7 @@ pub const COMMAND_NAME: &str = "recompress";
 
 #[derive(Args, Debug)]
 #[command(about = "Recompress a BVGraph", long_about = None)]
-struct CliArgs {
+pub struct CliArgs {
     /// The basename of the graph.
     basename: PathBuf,
     /// The basename for the newly compressed graph.
@@ -70,7 +70,7 @@ pub fn main(submatches: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
-fn compress<E: Endianness + Clone + Send + Sync>(
+pub fn compress<E: Endianness + Clone + Send + Sync>(
     args: CliArgs,
     target_endianness: Option<String>,
     permutation: Option<JavaPermutation>,

--- a/src/cli/simplify.rs
+++ b/src/cli/simplify.rs
@@ -17,7 +17,7 @@ pub const COMMAND_NAME: &str = "simplify";
 
 #[derive(Args, Debug)]
 #[command(about = "Simplify a BVGraph, i.e. make it undirected and remove duplicates and selfloops", long_about = None)]
-struct CliArgs {
+pub struct CliArgs {
     /// The basename of the graph.
     basename: PathBuf,
     /// The basename of the transposed graph. Defaults to `basename` + `.simple`.
@@ -55,7 +55,7 @@ pub fn main(submatches: &ArgMatches) -> Result<()> {
     }
 }
 
-fn simplify<E: Endianness + 'static>(args: CliArgs) -> Result<()>
+pub fn simplify<E: Endianness + 'static>(args: CliArgs) -> Result<()>
 where
     for<'a> BufBitReader<E, MemWordReader<u32, &'a [u32]>>: CodeRead<E> + BitSeek,
 {

--- a/src/cli/to_csv.rs
+++ b/src/cli/to_csv.rs
@@ -54,7 +54,7 @@ pub fn main(submatches: &ArgMatches) -> Result<()> {
     }
 }
 
-fn to_csv<E: Endianness + 'static>(basename: &str, sep: &str) -> Result<()>
+pub fn to_csv<E: Endianness + 'static>(basename: &str, sep: &str) -> Result<()>
 where
     for<'a> BufBitReader<E, MemWordReader<u32, &'a [u32]>>: CodeRead<E> + BitSeek,
 {

--- a/src/cli/transpose.rs
+++ b/src/cli/transpose.rs
@@ -17,7 +17,7 @@ pub const COMMAND_NAME: &str = "transpose";
 
 #[derive(Args, Debug)]
 #[command(about = "Transpose a BVGraph", long_about = None)]
-struct CliArgs {
+pub struct CliArgs {
     /// The basename of the graph.
     basename: PathBuf,
     /// The basename of the transposed graph. Defaults to `basename` + `-t`.
@@ -55,7 +55,7 @@ pub fn main(submatches: &ArgMatches) -> Result<()> {
     }
 }
 
-fn transpose<E: Endianness + 'static>(args: CliArgs) -> Result<()>
+pub fn transpose<E: Endianness + 'static>(args: CliArgs) -> Result<()>
 where
     for<'a> BufBitReader<E, MemWordReader<u32, &'a [u32]>>: CodeRead<E> + BitSeek,
 {


### PR DESCRIPTION
So they can be 're-exported' by other crates without having to instruct users to 'cargo install webgraph', and obey these crates' lockfile.

This was already done for the subcommands in `build/` for this reason.

I'm only interested in LLP, but I figured it made sense to do this for all subcommands.