### PR TITLE
"Could not create BatchIterator temporary file" on Windows fix

### DIFF
--- a/src/utils/sort_pairs.rs
+++ b/src/utils/sort_pairs.rs
@@ -306,6 +306,17 @@ impl<D: BitDeserializer<NE, BitReader>> BatchIterator<D> {
     where
         S::SerType: Send + Sync + Copy,
     {
+        // make sure directory exists before creating any files in it
+        let dir = file_path.as_ref().parent()
+            .expect("BatchIterator temporary file directory should have parent");
+        std::fs::create_dir_all(dir)
+            .with_context(|| {
+                format!(
+                    "Could not create BatchIterator temporary file directory {}",
+                    dir.display()
+                )
+            })?;
+
         // create a batch file where to dump
         let file_path = file_path.as_ref();
         let file = std::io::BufWriter::with_capacity(


### PR DESCRIPTION
**Description:**

There's an issue with `from csv` on Windows, following command:

> ./webgraph.exe from csv <input.csv --num_nodes 6573 output

results in:

> [2024-07-27T20:43:04Z INFO  webgraph.exe] Reading arcs CSV
> [2024-07-27T20:43:04Z INFO  webgraph.exe] Completed.
> [2024-07-27T20:43:04Z INFO  webgraph.exe] Elapsed: 44ms [10,000 lines, 222602.13 lines/s, 4.49 μs/lines]; res/vir/avail/free/total mem 0.00B/0.00B/8.52GB/8.52GB/17.11GB
> [2024-07-27T20:43:04Z INFO  webgraph::cli::from::csv] Arcs read: 10000
> [2024-07-27T20:43:04Z DEBUG webgraph::utils::sort_pairs] Sorted 10000 arcs in 2.4946ms
> thread 'main' panicked at src\cli\from\csv.rs:122:14:
> called `Result::unwrap()` on an `Err` value: Could not create BatchIterator temporary file C:\Users\wikto\AppData\Local\Temp\FromCsvPairs8e4rM5\000000
> 
> Caused by:
>     The system cannot find the path specified. (os error 3)
> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

**Cause:**

`std::fs::File::create` fails on some platforms if the directory doesn't exist.

**Solution:**

The issue is resolved by making sure temporary file's directory exists (not only on Windows). 

**Question:**

As I only use `from csv`, I'm not sure if other places suffer from it, too.
Should this PR include fixes in other places?