### PR TITLE
Replace anyhow::Error with enums in bvgraph::load

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ fuzz = ["dep:arbitrary", "dep:zip", "dsi-bitstream/fuzz"] # Expose the fuzzing h
 
 [dependencies]
 anyhow = { version = "1.0.79", features=["backtrace"]}
+thiserror = "1.0.63"
 java-properties = "2.0.0"
 mmap-rs = "0.6.1"
 num_cpus = "1.16.0"

--- a/src/graphs/bvgraph/codecs/dec_stats.rs
+++ b/src/graphs/bvgraph/codecs/dec_stats.rs
@@ -90,8 +90,12 @@ where
     where
         Self: 'a;
 
+    type Error<'a> = <F as SequentialDecoderFactory>::Error<'a>
+    where
+        Self: 'a;
+
     #[inline(always)]
-    fn new_decoder(&self) -> anyhow::Result<Self::Decoder<'_>> {
+    fn new_decoder(&self) -> Result<Self::Decoder<'_>, Self::Error<'_>> {
         Ok(StatsDecoder::new(
             self,
             self.factory.new_decoder()?,

--- a/src/graphs/bvgraph/codecs/mod.rs
+++ b/src/graphs/bvgraph/codecs/mod.rs
@@ -98,9 +98,12 @@ pub trait RandomAccessDecoderFactory {
     type Decoder<'a>: Decode + 'a
     where
         Self: 'a;
+    type Error<'a>: std::error::Error
+    where
+        Self: 'a;
 
     /// Creates a new reader starting at the given node.
-    fn new_decoder(&self, node: usize) -> anyhow::Result<Self::Decoder<'_>>;
+    fn new_decoder(&self, node: usize) -> Result<Self::Decoder<'_>, Self::Error<'_>>;
 }
 
 /// A trait providing decoders on the whole graph.
@@ -109,7 +112,10 @@ pub trait SequentialDecoderFactory {
     type Decoder<'a>: Decode + 'a
     where
         Self: 'a;
+    type Error<'a>: std::error::Error
+    where
+        Self: 'a;
 
     /// Creates a new reader starting at the given node.
-    fn new_decoder(&self) -> anyhow::Result<Self::Decoder<'_>>;
+    fn new_decoder(&self) -> Result<Self::Decoder<'_>, Self::Error<'_>>;
 }


### PR DESCRIPTION
This allows crates using epserde to unwrap errors and `match` them.

In my case, I would like to display a custom message on WrongTypeHash/VersionMismatch with instructions to regenerate files with the current epserde version. Currently this is not enough for this use case (because epserde still returns anyhow::Error), but https://github.com/vigna/epserde-rs/pull/32 will take care of it once merged.