### PR TITLE
Fixed division by zero when flag -f is enabled

### DIFF
--- a/src/cli/bench/bvgraph.rs
+++ b/src/cli/bench/bvgraph.rs
@@ -14,6 +14,7 @@ use lender::*;
 use rand::rngs::SmallRng;
 use rand::Rng;
 use rand::SeedableRng;
+use std::cmp::max;
 use std::hint::black_box;
 use std::path::PathBuf;
 
@@ -109,7 +110,7 @@ fn bench_random(graph: impl RandomAccessGraph, samples: usize, repeats: usize, f
         println!(
             "{}:    {:>20} ns/arc",
             if first { "First" } else { "Random" },
-            (start.elapsed().as_secs_f64() / c as f64) * 1e9
+            (start.elapsed().as_secs_f64() / max(1, c) as f64) * 1e9
         );
     }
 }

--- a/src/cli/bench/bvgraph.rs
+++ b/src/cli/bench/bvgraph.rs
@@ -14,7 +14,6 @@ use lender::*;
 use rand::rngs::SmallRng;
 use rand::Rng;
 use rand::SeedableRng;
-use std::cmp::max;
 use std::hint::black_box;
 use std::path::PathBuf;
 
@@ -95,6 +94,7 @@ fn bench_random(graph: impl RandomAccessGraph, samples: usize, repeats: usize, f
                         .next()
                         .unwrap_or(0),
                 );
+                c += 1;
             }
         } else {
             for _ in 0..samples {
@@ -110,7 +110,7 @@ fn bench_random(graph: impl RandomAccessGraph, samples: usize, repeats: usize, f
         println!(
             "{}:    {:>20} ns/arc",
             if first { "First" } else { "Random" },
-            (start.elapsed().as_secs_f64() / max(1, c) as f64) * 1e9
+            (start.elapsed().as_secs_f64() / c as f64) * 1e9
         );
     }
 }


### PR DESCRIPTION
Fixed division by zero during bench for random access when -f flag (first) is enabled

Note: I used std::cmp::max instead of the method max on u64 because it was overrided by the implementation of Iterator for u64 in the crate prelude