### PR TITLE
Relax dependency on chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ env_logger = { version = "0.11.5" }
 
 [build-dependencies]
 built = { version = "0.7", features = ["git2"] }
-chrono = "0.4.40"
+chrono = "0.4.39"
 
 [[bin]]
 name = "webgraph"


### PR DESCRIPTION
chrono 0.4.40 added a Datelike::quarter method, which [conflicts with a trait provided by arrow-rs](https://github.com/apache/arrow-rs/issues/7196), so some crates requires 'chrono < 0.4.40'