### PR TITLE
Use resolver 2 instead of 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "3"
+resolver = "2"
 members = [
     "algo", 
     "cli",


### PR DESCRIPTION
resolver 3 requires dependent crates referencing the git repo to have resolver 3 themselves, which requires edition 2024.

edition 2024 requires rustc 1.85 released last month and non-trivial changes in some of said crates, so it is a bit early to require it now.