### PR TITLE
Switch from edition 2024 to 2021

### DIFF
--- a/algo/Cargo.toml
+++ b/algo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "webgraph-algo"
 version = "0.1.1"
-edition = "2024"
+edition = "2021"
 description = "Algorithms for the Rust port of the WebGraph framework (http://webgraph.di.unimi.it/)."
 repository = "https://github.com/vigna/webgraph-rs/"
 license = "Apache-2.0 OR LGPL-2.1-or-later"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "webgraph_cli"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 authors = [
 	"Tommaso Fontana <tommaso.fontana.96@gmail.com>",
 	"Sebastiano Vigna <sebastiano.vigna@unimi.it>",

--- a/webgraph/Cargo.toml
+++ b/webgraph/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "webgraph"
 version = "0.2.1"
-edition = "2024"
+edition = "2021"
 description = "A Rust port of the WebGraph framework (http://webgraph.di.unimi.it/)."
 repository = "https://github.com/vigna/webgraph-rs/"
 license = "Apache-2.0 OR LGPL-2.1-or-later"


### PR DESCRIPTION
There is no reason to depend on edition 2021 yet, and it requires a very recent compiler (1.85, released last month)