### PR TITLE
Make SortedIterator implementable by other crates

### DIFF
--- a/webgraph/src/graphs/random/er.rs
+++ b/webgraph/src/graphs/random/er.rs
@@ -64,7 +64,7 @@ impl SequentialLabeling for ErdosRenyi {
 }
 
 unsafe impl SortedLender for Iter {}
-unsafe impl SortedIterator for <Succ as IntoIterator>::IntoIter {}
+unsafe impl SortedIterator for SuccIntoIter {}
 
 #[derive(Debug, Clone)]
 pub struct Iter {


### PR DESCRIPTION
This is crazy, but despite `<Succ as IntoIterator>::IntoIter` being equivalent to `SuccIntoIter`, the way this was written prevented implementing it on other types.

For example, this code:

```rust
use webgraph::prelude::*;

pub struct Test<I: Iterator>(I);

impl<I: Iterator> Iterator for Test<I> {
    type Item = <I as Iterator>::Item;

    fn next(&mut self) -> Option<Self::Item> {
        self.0.next()
    }
}

unsafe impl<I: SortedIterator> SortedIterator for Test<I>
{
}
```

failed with:

```
error[E0119]: conflicting implementations of trait `webgraph::traits::SortedIterator` for type `<webgraph::graphs::random::er::Succ as IntoIterator>::IntoIter`
  --> repro.rs:13:1
   |
13 | unsafe impl<I: SortedIterator> SortedIterator for Test<I>
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: conflicting implementation in crate `webgraph`:
           - impl webgraph::traits::SortedIterator for <webgraph::graphs::random::er::Succ as IntoIterator>::IntoIter;

For more information about this error, try `rustc --explain E0119`.
```