### PR TITLE
Remove guarantee that RightIterator/RightIntoIter is sorted

### DIFF
--- a/webgraph/src/labels/proj.rs
+++ b/webgraph/src/labels/proj.rs
@@ -415,12 +415,3 @@ where
 impl<S: SequentialLabeling> SequentialGraph for Right<S> where S::Label: Pair<Right = usize> {}
 
 impl<R: RandomAccessLabeling> RandomAccessGraph for Right<R> where R::Label: Pair<Right = usize> {}
-
-unsafe impl<L: SortedLender> SortedLender for RightIterator<L>
-where
-    L: Lender + for<'next> NodeLabelsLender<'next>,
-    for<'next> LenderLabel<'next, L>: Pair,
-{
-}
-
-unsafe impl<I: SortedIterator> SortedIterator for RightIntoIter<I> where I::Item: Pair {}


### PR DESCRIPTION
It's incorrect, because RightIterator([(0, 2), (1, 0)]) is [2, 0], which is not sorted. Only LeftIterator/LeftIntoIter is.