### PR TITLE
Fix wrong endiannes in properties saved by BvComp::parallel_iter

### DIFF
--- a/webgraph/src/graphs/bvgraph/comp/impls.rs
+++ b/webgraph/src/graphs/bvgraph/comp/impls.rs
@@ -458,7 +458,7 @@ impl BvComp<()> {
 
             log::info!("Writing the .properties file");
             let properties = compression_flags
-                .to_properties::<BE>(num_nodes, total_arcs, total_written_bits)
+                .to_properties::<E>(num_nodes, total_arcs, total_written_bits)
                 .context("Could not serialize properties")?;
             let properties_path = basename.with_extension(PROPERTIES_EXTENSION);
             std::fs::write(&properties_path, properties).with_context(|| {


### PR DESCRIPTION
Same issue as bf1a4c890c1c5bc8c6d647094acf0b62939069a6