### PR TITLE
Add BvCompBuilder

### DIFF
--- a/webgraph/src/graphs/bvgraph/comp/mod.rs
+++ b/webgraph/src/graphs/bvgraph/comp/mod.rs
@@ -9,6 +9,7 @@ mod bvcomp;
 pub use bvcomp::*;
 
 mod impls;
+pub use impls::BvCompBuilder;
 
 mod flags;
 pub use flags::*;


### PR DESCRIPTION
As discussed in https://github.com/vigna/webgraph-rs/pull/103#issuecomment-3349131253

This holds arguments shared by various associated functions, and provides default values

I'm not very happy with this implementation, but I don't see a better way.

In particular, I need both `fn ensure_tmp_dir(&mut self) -> Result<()>` and `fn tmp_dir(&self) -> &PathBuf` because unifying them as a single `fn (&mut self) -> Result<&PathBuf>` function means that the return `PathBuf` still mutably borrows the instance, preventing any other method call.