### PR TITLE
Introduce BatchCodec to substitute BatchIterator

### DIFF
--- a/webgraph/examples/bench_sort_pairs.rs
+++ b/webgraph/examples/bench_sort_pairs.rs
@@ -18,6 +18,7 @@ use rand::RngCore;
 use rand::SeedableRng;
 use tempfile::Builder;
 use webgraph::prelude::*;
+use webgraph::utils::gaps::GapsCodec;
 
 #[derive(Parser, Debug)]
 #[command(about = "Tests the merge speed of SortPairs", long_about = None)]
@@ -62,11 +63,13 @@ pub fn main() -> Result<()> {
     let dir = Builder::new().prefix("bench_sort_pairs").tempdir()?;
 
     if args.labeled {
-        let mut sp = SortPairs::<Mock, Mock>::new_labeled(
+        let mut sp = SortPairs::new_labeled(
             MemoryUsage::BatchSize(args.batch),
             dir.path(),
-            Mock(),
-            Mock(),
+            GapsCodec::<_, _> {
+                serializer: Mock(),
+                deserializer: Mock(),
+            },
         )?;
 
         let mut r = SmallRng::seed_from_u64(0);

--- a/webgraph/examples/bench_sort_pairs.rs
+++ b/webgraph/examples/bench_sort_pairs.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use clap::Parser;
 use dsi_bitstream::traits::BitRead;
 use dsi_bitstream::traits::BitWrite;
-use dsi_bitstream::traits::Endianness;
+use dsi_bitstream::traits::{Endianness, BE};
 use dsi_progress_logger::prelude::{ProgressLog, ProgressLogger};
 use rand::rngs::SmallRng;
 use rand::RngCore;
@@ -66,10 +66,7 @@ pub fn main() -> Result<()> {
         let mut sp = SortPairs::new_labeled(
             MemoryUsage::BatchSize(args.batch),
             dir.path(),
-            GapsCodec::<_, _> {
-                serializer: Mock(),
-                deserializer: Mock(),
-            },
+            GapsCodec::<BE, _, _>::new(Mock(), Mock()),
         )?;
 
         let mut r = SmallRng::seed_from_u64(0);

--- a/webgraph/examples/bench_unit_transpose.rs
+++ b/webgraph/examples/bench_unit_transpose.rs
@@ -78,8 +78,7 @@ where
         let mut iter = Left(transform::transpose_labeled(
             &unit,
             MemoryUsage::BatchSize(10_000_000),
-            (),
-            (),
+            DefaultBatchCodec::default(),
         )?)
         .iter();
         while let Some((x, s)) = iter.next() {

--- a/webgraph/src/transform/perm.rs
+++ b/webgraph/src/transform/perm.rs
@@ -5,7 +5,7 @@
  */
 
 use crate::graphs::arc_list_graph;
-use crate::prelude::sort_pairs::{BatchIterator, KMergeIters};
+use crate::prelude::sort_pairs::KMergeIters;
 use crate::prelude::*;
 use anyhow::{ensure, Context, Result};
 use dsi_progress_logger::prelude::*;
@@ -26,7 +26,7 @@ pub fn permute(
     graph: &impl SequentialGraph,
     perm: &impl SliceByValue<Value = usize>,
     memory_usage: MemoryUsage,
-) -> Result<Left<arc_list_graph::ArcListGraph<KMergeIters<BatchIterator<()>, ()>>>> {
+) -> Result<Left<arc_list_graph::ArcListGraph<KMergeIters<CodecIter<DefaultBatchCodec>, ()>>>> {
     ensure!(
         perm.len() == graph.num_nodes(),
         "The given permutation has {} values and thus it's incompatible with a graph with {} nodes.",
@@ -79,7 +79,7 @@ pub fn permute_split<S, P>(
     perm: &P,
     memory_usage: MemoryUsage,
     threads: &ThreadPool,
-) -> Result<Left<arc_list_graph::ArcListGraph<KMergeIters<BatchIterator<()>, ()>>>>
+) -> Result<Left<arc_list_graph::ArcListGraph<KMergeIters<CodecIter<DefaultBatchCodec>, ()>>>>
 where
     S: SequentialGraph + SplitLabeling,
     P: SliceByValue<Value = usize> + Send + Sync + Clone,

--- a/webgraph/src/transform/transpose.rs
+++ b/webgraph/src/transform/transpose.rs
@@ -7,15 +7,14 @@
 
 use crate::graphs::arc_list_graph;
 use crate::prelude::proj::Left;
-use crate::prelude::sort_pairs::{BatchIterator, BitReader, BitWriter, KMergeIters};
-use crate::prelude::{
-    BitDeserializer, BitSerializer, LabeledSequentialGraph, SequentialGraph, SortPairs,
-};
+use crate::prelude::sort_pairs::KMergeIters;
+use crate::prelude::{LabeledSequentialGraph, SequentialGraph, SortPairs};
 use crate::traits::graph::UnitLabelGraph;
 use crate::traits::{NodeLabelsLender, SplitLabeling};
-use crate::utils::{MemoryUsage, ParSortIters, SplitIters};
+use crate::utils::{
+    BatchCodec, CodecIter, DefaultBatchCodec, MemoryUsage, ParSortIters, SplitIters,
+};
 use anyhow::Result;
-use dsi_bitstream::traits::NE;
 use dsi_progress_logger::prelude::*;
 use lender::prelude::*;
 use tempfile::Builder;
@@ -25,21 +24,18 @@ use tempfile::Builder;
 ///
 /// For the meaning of the additional parameters, see
 /// [`SortPairs`](crate::prelude::sort_pairs::SortPairs).
-pub fn transpose_labeled<
-    S: BitSerializer<NE, BitWriter> + Clone,
-    D: BitDeserializer<NE, BitReader> + Clone + 'static,
->(
-    graph: &impl LabeledSequentialGraph<S::SerType>,
+#[allow(clippy::type_complexity)]
+pub fn transpose_labeled<C: BatchCodec>(
+    graph: &impl LabeledSequentialGraph<C::Label>,
     memory_usage: MemoryUsage,
-    serializer: S,
-    deserializer: D,
-) -> Result<arc_list_graph::ArcListGraph<KMergeIters<BatchIterator<D>, D::DeserType>>>
+    batch_codec: C,
+) -> Result<arc_list_graph::ArcListGraph<KMergeIters<CodecIter<C>, C::Label>>>
 where
-    S::SerType: Send + Sync + Copy,
-    D::DeserType: Clone + Copy,
+    C::Label: Clone + 'static,
+    CodecIter<C>: Clone + Send + Sync,
 {
     let dir = Builder::new().prefix("transpose_").tempdir()?;
-    let mut sorted = SortPairs::new_labeled(memory_usage, dir.path(), serializer, deserializer)?;
+    let mut sorted = SortPairs::new_labeled(memory_usage, dir.path(), batch_codec)?;
 
     let mut pl = progress_logger![
         item_name = "node",
@@ -69,12 +65,11 @@ where
 pub fn transpose(
     graph: impl SequentialGraph,
     memory_usage: MemoryUsage,
-) -> Result<Left<arc_list_graph::ArcListGraph<KMergeIters<BatchIterator<()>, ()>>>> {
+) -> Result<Left<arc_list_graph::ArcListGraph<KMergeIters<CodecIter<DefaultBatchCodec>, ()>>>> {
     Ok(Left(transpose_labeled(
         &UnitLabelGraph(graph),
         memory_usage,
-        (),
-        (),
+        DefaultBatchCodec::default(),
     )?))
 }
 
@@ -90,32 +85,28 @@ pub fn transpose(
 pub fn transpose_labeled_split<
     'graph,
     G: 'graph
-        + LabeledSequentialGraph<S::SerType>
+        + LabeledSequentialGraph<C::Label>
         + for<'a> SplitLabeling<
             SplitLender<'a>: for<'b> NodeLabelsLender<
                 'b,
-                Label: crate::traits::Pair<Left = usize, Right = S::SerType> + Copy,
+                Label: crate::traits::Pair<Left = usize, Right = C::Label> + Copy,
                 IntoIterator: IntoIterator<IntoIter: Send + Sync>,
             > + Send
                                  + Sync,
             IntoIterator<'a>: IntoIterator<IntoIter: Send + Sync>,
         >,
-    S: BitSerializer<NE, BitWriter> + Clone + Send + Sync + 'graph,
-    D: BitDeserializer<NE, BitReader, DeserType: Clone + Send + Sync> + Clone + Send + Sync + 'static,
+    C: BatchCodec + 'graph,
 >(
     graph: &'graph G,
     memory_usage: MemoryUsage,
-    serializer: S,
-    deserializer: D,
+    batch_codec: C,
 ) -> Result<
     SplitIters<
-        impl IntoIterator<Item = ((usize, usize), D::DeserType), IntoIter: Send + Sync>
-            + use<'graph, G, S, D>,
+        impl IntoIterator<Item = ((usize, usize), C::Label), IntoIter: Send + Sync> + use<'graph, G, C>,
     >,
 >
 where
-    S::SerType: Send + Sync + Copy,
-    D::DeserType: Clone + Copy,
+    CodecIter<C>: Clone + Send + Sync,
 {
     let par_sort_iters = ParSortIters::new(graph.num_nodes())?.memory_usage(memory_usage);
     let parts = num_cpus::get();
@@ -126,11 +117,7 @@ where
         .map(|iter| iter.into_labeled_pairs().map(|((a, b), l)| ((b, a), l)))
         .collect();
 
-    par_sort_iters.try_sort_labeled::<S, D, std::convert::Infallible>(
-        &serializer,
-        deserializer,
-        pairs,
-    )
+    par_sort_iters.try_sort_labeled::<C, std::convert::Infallible>(batch_codec, pairs)
 }
 
 /// Returns a [`SplitIters`] structure representing the
@@ -170,8 +157,9 @@ pub fn transpose_split<
         .map(|iter| iter.into_pairs().map(|(src, dst)| ((dst, src), ())))
         .collect();
 
-    let SplitIters { boundaries, iters } =
-        par_sort_iters.try_sort_labeled::<(), (), std::convert::Infallible>(&(), (), pairs)?;
+    let batch_codec = DefaultBatchCodec::default();
+    let SplitIters { boundaries, iters } = par_sort_iters
+        .try_sort_labeled::<DefaultBatchCodec, std::convert::Infallible>(batch_codec, pairs)?;
 
     Ok(SplitIters {
         boundaries,

--- a/webgraph/src/utils/batch_codec/gaps.rs
+++ b/webgraph/src/utils/batch_codec/gaps.rs
@@ -27,17 +27,15 @@ use rdst::*;
 /// This codec encodes triples of the form `(src, dst, label)` by encoding the
 /// gaps between consecutive sources and destinations using a specified code.
 ///
-/// ## Type Parameters
+/// # Type Parameters
+///
 /// - `S`: Serializer for the labels, implementing [`BitSerializer`] for the label type.
 /// - `D`: Deserializer for the labels, implementing [`BitDeserializer`] for the label type.
 /// - `SRC_CODE`: Code used for encoding source gaps (default: gamma).
 /// - `DST_CODE`: Code used for encoding destination gaps (default: gamma).
 ///
-/// ## Fields
-/// - `serializer`: The label serializer.
-/// - `deserializer`: The label deserializer.
+/// # Encoding Format
 ///
-/// ## Encoding Format
 /// 1. The batch length is written using delta coding.
 /// 2. For each group of triples with the same source:
 ///     - The gap from the previous source is encoded.
@@ -47,39 +45,6 @@ use rdst::*;
 /// The bit deserializer must be [`Clone`] because we need one for each
 /// [`GapsIterator`], and there are possible scenarios in which the
 /// deserializer might be stateful.
-///
-/// ## Choosing the codes
-///
-/// These are the top 10 codes for src and dst gaps when transposing `enwiki-2024`.
-/// ```ignore
-/// Src codes:
-///   Code: Unary        Size: 179553432
-///   Code: Golomb(1)    Size: 179553432
-///   Code: Rice(0)      Size: 179553432
-///   Code: Gamma        Size: 185374984
-///   Code: Zeta(1)      Size: 185374984
-///   Code: ExpGolomb(0) Size: 185374984
-///   Code: Omega        Size: 185439656
-///   Code: Delta        Size: 191544794
-///   Code: Golomb(2)    Size: 345986198
-///   Code: Rice(1)      Size: 345986198
-/// Dst codes:
-///   Code: Pi(2)   Size: 2063880685
-///   Code: Pi(3)   Size: 2074138948
-///   Code: Zeta(3) Size: 2122730298
-///   Code: Zeta(4) Size: 2123948774
-///   Code: Zeta(5) Size: 2169131998
-///   Code: Pi(4)   Size: 2176097847
-///   Code: Zeta(2) Size: 2226573622
-///   Code: Zeta(6) Size: 2237680403
-///   Code: Delta   Size: 2272691460
-///   Code: Zeta(7) Size: 2305354857
-/// ```
-///
-/// So the best combination is `Unary` for src gaps and `Pi(2)` for dst gaps.
-/// But, `Unary` can behave poorly if the distribution of your data changes,
-/// therefore the recommended default is `Gamma` for src gaps and `Delta` for
-/// dst gaps as they are universal codes.
 pub struct GapsCodec<
     E: Endianness = NE,
     S: BitSerializer<E, BitWriter<E>> = (),

--- a/webgraph/src/utils/batch_codec/gaps.rs
+++ b/webgraph/src/utils/batch_codec/gaps.rs
@@ -1,0 +1,254 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Inria
+ * SPDX-FileCopyrightText: 2023 Sebastiano Vigna
+ * SPDX-FileCopyrightText: 2025 Tommaso Fontana
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+use super::{BitReader, BitWriter};
+use crate::traits::SortedIterator;
+use crate::utils::{ArcMmapHelper, MmapHelper, Triple};
+use crate::{
+    traits::{BitDeserializer, BitSerializer},
+    utils::BatchCodec,
+};
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use dsi_bitstream::prelude::*;
+use mmap_rs::MmapFlags;
+use rdst::*;
+
+#[derive(Clone, Debug, Default)]
+/// A codec for encoding and decoding batches of triples using gap compression.
+///
+/// This codec encodes triples of the form `(src, dst, label)` by encoding the
+/// gaps between consecutive sources and destinations using a specified code.
+///
+/// ## Type Parameters
+/// - `S`: Serializer for the labels, implementing [`BitSerializer`] for the label type.
+/// - `D`: Deserializer for the labels, implementing [`BitDeserializer`] for the label type.
+/// - `SRC_CODE`: Code used for encoding source gaps (default: gamma).
+/// - `DST_CODE`: Code used for encoding destination gaps (default: gamma).
+///
+/// ## Fields
+/// - `serializer`: The label serializer.
+/// - `deserializer`: The label deserializer.
+///
+/// ## Encoding Format
+/// 1. The batch length is written using delta coding.
+/// 2. For each group of triples with the same source:
+///     - The gap from the previous source is encoded.
+///     - The gap from the previous destination is encoded.
+///     - The label is serialized.
+///
+/// The bit deserializer must be [`Clone`] because we need one for each
+/// [`GapsIterator`], and there are possible scenarios in which the
+/// deserializer might be stateful.
+///
+/// ## Choosing the codes
+///
+/// These are the top 10 codes for src and dst gaps when transposing `enwiki-2024`.
+/// ```ignore
+/// Src codes:
+///   Code: Unary        Size: 179553432
+///   Code: Golomb(1)    Size: 179553432
+///   Code: Rice(0)      Size: 179553432
+///   Code: Gamma        Size: 185374984
+///   Code: Zeta(1)      Size: 185374984
+///   Code: ExpGolomb(0) Size: 185374984
+///   Code: Omega        Size: 185439656
+///   Code: Delta        Size: 191544794
+///   Code: Golomb(2)    Size: 345986198
+///   Code: Rice(1)      Size: 345986198
+/// Dst codes:
+///   Code: Pi(2)   Size: 2063880685
+///   Code: Pi(3)   Size: 2074138948
+///   Code: Zeta(3) Size: 2122730298
+///   Code: Zeta(4) Size: 2123948774
+///   Code: Zeta(5) Size: 2169131998
+///   Code: Pi(4)   Size: 2176097847
+///   Code: Zeta(2) Size: 2226573622
+///   Code: Zeta(6) Size: 2237680403
+///   Code: Delta   Size: 2272691460
+///   Code: Zeta(7) Size: 2305354857
+/// ```
+///
+/// So the best combination is `Unary` for src gaps and `Pi(2)` for dst gaps.
+/// But, `Unary` can behave poorly if the distribution of your data changes,
+/// therefore the recommended default is `Gamma` for src gaps and `Delta` for
+/// dst gaps as they are universal codes.
+pub struct GapsCodec<
+    S: BitSerializer<NE, BitWriter> = (),
+    D: BitDeserializer<NE, BitReader, DeserType = S::SerType> + Clone = (),
+    const SRC_CODE: usize = { dsi_bitstream::dispatch::code_consts::GAMMA },
+    const DST_CODE: usize = { dsi_bitstream::dispatch::code_consts::DELTA },
+> {
+    /// Serializer for the labels
+    pub serializer: S,
+    /// Deserializer for the labels
+    pub deserializer: D,
+}
+
+impl<S, D, const SRC_CODE: usize, const DST_CODE: usize> BatchCodec
+    for GapsCodec<S, D, SRC_CODE, DST_CODE>
+where
+    S: BitSerializer<NE, BitWriter> + Send + Sync,
+    D: BitDeserializer<NE, BitReader, DeserType = S::SerType> + Send + Sync + Clone,
+    S::SerType: Send + Sync + Copy + 'static + core::fmt::Debug, // needed by radix sort
+{
+    type Label = S::SerType;
+    type DecodedBatch = GapsIterator<D, SRC_CODE, DST_CODE>;
+
+    fn encode_batch(
+        &self,
+        path: impl AsRef<std::path::Path>,
+        batch: &mut [((usize, usize), Self::Label)],
+    ) -> Result<usize> {
+        let start = std::time::Instant::now();
+        Triple::cast_batch_mut(batch).radix_sort_unstable();
+        log::debug!("Sorted {} arcs in {:?}", batch.len(), start.elapsed());
+        self.encode_sorted_batch(path, batch)
+    }
+
+    fn encode_sorted_batch(
+        &self,
+        path: impl AsRef<std::path::Path>,
+        batch: &[((usize, usize), Self::Label)],
+    ) -> Result<usize> {
+        debug_assert!(Triple::cast_batch(batch).is_sorted());
+        // create a batch file where to dump
+        let file_path = path.as_ref();
+        let file = std::io::BufWriter::with_capacity(
+            1 << 16,
+            std::fs::File::create(file_path).with_context(|| {
+                format!(
+                    "Could not create BatchIterator temporary file {}",
+                    file_path.display()
+                )
+            })?,
+        );
+        // create a bitstream to write to the file
+        let mut stream = <BufBitWriter<NE, _>>::new(<WordAdapter<usize, _>>::new(file));
+
+        // prefix the stream with the length of the batch
+        // we use a delta code since it'll be a big number most of the time
+        stream
+            .write_delta(batch.len() as u64)
+            .context("Could not write length")?;
+
+        // dump the triples to the bitstream
+        let (mut prev_src, mut prev_dst) = (0, 0);
+        let mut written_bits = 0;
+        for ((src, dst), label) in batch.iter() {
+            // write the source gap as gamma
+            written_bits += ConstCode::<SRC_CODE>
+                .write(&mut stream, (src - prev_src) as u64)
+                .with_context(|| format!("Could not write {src} after {prev_src}"))?;
+            if *src != prev_src {
+                // Reset prev_y
+                prev_dst = 0;
+            }
+            // write the destination gap as gamma
+            written_bits += ConstCode::<DST_CODE>
+                .write(&mut stream, (dst - prev_dst) as u64)
+                .with_context(|| format!("Could not write {dst} after {prev_dst}"))?;
+            // write the label
+            written_bits += self
+                .serializer
+                .serialize(label, &mut stream)
+                .context("Could not serialize label")?;
+            (prev_src, prev_dst) = (*src, *dst);
+        }
+        // flush the stream and reset the buffer
+        written_bits += stream.flush().context("Could not flush stream")?;
+
+        Ok(written_bits)
+    }
+
+    fn decode_batch(&self, path: impl AsRef<std::path::Path>) -> Result<Self::DecodedBatch> {
+        // open the file
+        let mut stream = <BufBitReader<NE, _>>::new(MemWordReader::new(ArcMmapHelper(Arc::new(
+            MmapHelper::mmap(
+                path.as_ref(),
+                MmapFlags::TRANSPARENT_HUGE_PAGES | MmapFlags::SEQUENTIAL,
+            )
+            .with_context(|| format!("Could not mmap {}", path.as_ref().display()))?,
+        ))));
+
+        // read the length of the batch (first value in the stream)
+        let len = stream.read_delta().context("Could not read length")? as usize;
+
+        // create the iterator
+        Ok(GapsIterator {
+            deserializer: self.deserializer.clone(),
+            stream,
+            len,
+            current: 0,
+            prev_src: 0,
+            prev_dst: 0,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+/// An iterator over triples encoded with gaps, this is returned by [`GapsCodec`].
+pub struct GapsIterator<
+    D: BitDeserializer<NE, BitReader> = (),
+    const SRC_CODE: usize = { dsi_bitstream::dispatch::code_consts::GAMMA },
+    const DST_CODE: usize = { dsi_bitstream::dispatch::code_consts::GAMMA },
+> {
+    /// Deserializer for the labels
+    deserializer: D,
+    /// Bitstream to read from
+    stream: BitReader,
+    /// Length of the iterator (number of triples)
+    len: usize,
+    /// Current position in the iterator
+    current: usize,
+    /// Previous source node
+    prev_src: usize,
+    /// Previous destination node
+    prev_dst: usize,
+}
+
+unsafe impl<D: BitDeserializer<NE, BitReader>, const SRC_CODE: usize, const DST_CODE: usize>
+    SortedIterator for GapsIterator<D, SRC_CODE, DST_CODE>
+{
+}
+
+impl<D: BitDeserializer<NE, BitReader>, const SRC_CODE: usize, const DST_CODE: usize> Iterator
+    for GapsIterator<D, SRC_CODE, DST_CODE>
+{
+    type Item = ((usize, usize), D::DeserType);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current >= self.len {
+            return None;
+        }
+        let src_gap = ConstCode::<SRC_CODE>.read(&mut self.stream).ok()?;
+        let dst_gap = ConstCode::<DST_CODE>.read(&mut self.stream).ok()?;
+        let label = self.deserializer.deserialize(&mut self.stream).ok()?;
+        self.prev_src += src_gap as usize;
+        if src_gap != 0 {
+            self.prev_dst = 0;
+        }
+        self.prev_dst += dst_gap as usize;
+        self.current += 1;
+        Some(((self.prev_src, self.prev_dst), label))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+impl<D: BitDeserializer<NE, BitReader>, const SRC_CODE: usize, const DST_CODE: usize>
+    ExactSizeIterator for GapsIterator<D, SRC_CODE, DST_CODE>
+{
+    fn len(&self) -> usize {
+        self.len - self.current
+    }
+}

--- a/webgraph/src/utils/batch_codec/grouped_gaps.rs
+++ b/webgraph/src/utils/batch_codec/grouped_gaps.rs
@@ -19,7 +19,7 @@ use dsi_bitstream::prelude::*;
 use mmap_rs::MmapFlags;
 use rdst::*;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 /// A codec for encoding and decoding batches of triples using grouped gap compression.
 ///
 /// This codec encodes triples of the form `(src, dst, label)` by grouping edges with the same source node,
@@ -94,27 +94,76 @@ use rdst::*;
 /// so the recommended defaults are `Gamma` for src gaps, `ExpGolomb3` for outdegree, and `Delta` for dst gaps,
 /// as they are universal codes.
 pub struct GroupedGapsCodec<
-    S: BitSerializer<NE, BitWriter> = (),
-    D: BitDeserializer<NE, BitReader, DeserType = S::SerType> + Clone = (),
+    E: Endianness = BE,
+    S: BitSerializer<E, BitWriter<E>> = (),
+    D: BitDeserializer<E, BitReader<E>, DeserType = S::SerType> + Clone = (),
     const OUTDEGREE_CODE: usize = { dsi_bitstream::dispatch::code_consts::EXP_GOLOMB3 },
     const SRC_CODE: usize = { dsi_bitstream::dispatch::code_consts::GAMMA },
     const DST_CODE: usize = { dsi_bitstream::dispatch::code_consts::DELTA },
-> {
+> where
+    BitReader<E>: BitRead<E>,
+    BitWriter<E>: BitWrite<E>,
+{
     /// Serializer for the labels
     pub serializer: S,
     /// Deserializer for the labels
     pub deserializer: D,
+
+    pub _marker: core::marker::PhantomData<E>,
 }
 
-impl<S, D, const OUTDEGREE_CODE: usize, const SRC_CODE: usize, const DST_CODE: usize> BatchCodec
-    for GroupedGapsCodec<S, D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+impl<E, S, D, const OUTDEGREE_CODE: usize, const SRC_CODE: usize, const DST_CODE: usize>
+    GroupedGapsCodec<E, S, D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
 where
-    S: BitSerializer<NE, BitWriter> + Send + Sync,
-    D: BitDeserializer<NE, BitReader, DeserType = S::SerType> + Send + Sync + Clone,
+    E: Endianness,
+    S: BitSerializer<E, BitWriter<E>> + Send + Sync,
+    D: BitDeserializer<E, BitReader<E>, DeserType = S::SerType> + Send + Sync + Clone,
+    BitReader<E>: BitRead<E>,
+    BitWriter<E>: BitWrite<E>,
+{
+    /// Creates a new `GroupedGapsCodec` with the given serializer and deserializer.
+    pub fn new(serializer: S, deserializer: D) -> Self {
+        Self {
+            serializer,
+            deserializer,
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<
+        E: Endianness,
+        S: BitSerializer<E, BitWriter<E>> + Default,
+        D: BitDeserializer<E, BitReader<E>, DeserType = S::SerType> + Clone + Default,
+        const OUTDEGREE_CODE: usize,
+        const SRC_CODE: usize,
+        const DST_CODE: usize,
+    > Default for GroupedGapsCodec<E, S, D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+where
+    BitReader<E>: BitRead<E>,
+    BitWriter<E>: BitWrite<E>,
+{
+    fn default() -> Self {
+        Self {
+            serializer: S::default(),
+            deserializer: D::default(),
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<E, S, D, const OUTDEGREE_CODE: usize, const SRC_CODE: usize, const DST_CODE: usize> BatchCodec
+    for GroupedGapsCodec<E, S, D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+where
+    E: Endianness,
+    S: BitSerializer<E, BitWriter<E>> + Send + Sync,
+    D: BitDeserializer<E, BitReader<E>, DeserType = S::SerType> + Send + Sync + Clone,
     S::SerType: Send + Sync + Copy + 'static, // needed by radix sort
+    BitReader<E>: BitRead<E> + CodesRead<E>,
+    BitWriter<E>: BitWrite<E> + CodesWrite<E>,
 {
     type Label = S::SerType;
-    type DecodedBatch = GroupedGapsIterator<D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>;
+    type DecodedBatch = GroupedGapsIterator<E, D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>;
 
     fn encode_batch(
         &self,
@@ -145,7 +194,7 @@ where
             })?,
         );
         // create a bitstream to write to the file
-        let mut stream = <BufBitWriter<NE, _>>::new(<WordAdapter<usize, _>>::new(file));
+        let mut stream = <BufBitWriter<E, _>>::new(<WordAdapter<usize, _>>::new(file));
 
         // prefix the stream with the length of the batch
         // we use a delta code since it'll be a big number most of the time
@@ -196,7 +245,7 @@ where
 
     fn decode_batch(&self, path: impl AsRef<std::path::Path>) -> Result<Self::DecodedBatch> {
         // open the file
-        let mut stream = <BufBitReader<NE, _>>::new(MemWordReader::new(ArcMmapHelper(Arc::new(
+        let mut stream = <BufBitReader<E, _>>::new(MemWordReader::new(ArcMmapHelper(Arc::new(
             MmapHelper::mmap(
                 path.as_ref(),
                 MmapFlags::TRANSPARENT_HUGE_PAGES | MmapFlags::SEQUENTIAL,
@@ -223,15 +272,19 @@ where
 #[derive(Clone, Debug)]
 /// An iterator over triples encoded with gaps, this is returned by [`GroupedGapsCodec`].
 pub struct GroupedGapsIterator<
-    D: BitDeserializer<NE, BitReader> = (),
+    E: Endianness = NE,
+    D: BitDeserializer<E, BitReader<E>> = (),
     const OUTDEGREE_CODE: usize = { dsi_bitstream::dispatch::code_consts::GAMMA },
     const SRC_CODE: usize = { dsi_bitstream::dispatch::code_consts::GAMMA },
     const DST_CODE: usize = { dsi_bitstream::dispatch::code_consts::GAMMA },
-> {
+> where
+    BitReader<E>: BitRead<E>,
+    BitWriter<E>: BitWrite<E>,
+{
     /// Deserializer for the labels
     deserializer: D,
     /// Bitstream to read from
-    stream: BitReader,
+    stream: BitReader<E>,
     /// Length of the iterator (number of triples)
     len: usize,
     /// Current position in the iterator
@@ -245,20 +298,28 @@ pub struct GroupedGapsIterator<
 }
 
 unsafe impl<
-        D: BitDeserializer<NE, BitReader>,
+        E: Endianness,
+        D: BitDeserializer<E, BitReader<E>>,
         const OUTDEGREE_CODE: usize,
         const SRC_CODE: usize,
         const DST_CODE: usize,
-    > SortedIterator for GroupedGapsIterator<D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+    > SortedIterator for GroupedGapsIterator<E, D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+where
+    BitReader<E>: BitRead<E> + CodesRead<E>,
+    BitWriter<E>: BitWrite<E> + CodesWrite<E>,
 {
 }
 
 impl<
-        D: BitDeserializer<NE, BitReader>,
+        E: Endianness,
+        D: BitDeserializer<E, BitReader<E>>,
         const OUTDEGREE_CODE: usize,
         const SRC_CODE: usize,
         const DST_CODE: usize,
-    > Iterator for GroupedGapsIterator<D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+    > Iterator for GroupedGapsIterator<E, D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+where
+    BitReader<E>: BitRead<E> + CodesRead<E>,
+    BitWriter<E>: BitWrite<E> + CodesWrite<E>,
 {
     type Item = ((usize, usize), D::DeserType);
     fn next(&mut self) -> Option<Self::Item> {
@@ -288,11 +349,15 @@ impl<
 }
 
 impl<
-        D: BitDeserializer<NE, BitReader>,
+        E: Endianness,
+        D: BitDeserializer<E, BitReader<E>>,
         const OUTDEGREE_CODE: usize,
         const SRC_CODE: usize,
         const DST_CODE: usize,
-    > ExactSizeIterator for GroupedGapsIterator<D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+    > ExactSizeIterator for GroupedGapsIterator<E, D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+where
+    BitReader<E>: BitRead<E> + CodesRead<E>,
+    BitWriter<E>: BitWrite<E> + CodesWrite<E>,
 {
     fn len(&self) -> usize {
         self.len - self.current

--- a/webgraph/src/utils/batch_codec/grouped_gaps.rs
+++ b/webgraph/src/utils/batch_codec/grouped_gaps.rs
@@ -1,0 +1,300 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Tommaso Fontana
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+use super::{BitReader, BitWriter};
+use crate::traits::SortedIterator;
+use crate::utils::{ArcMmapHelper, MmapHelper, Triple};
+use crate::{
+    traits::{BitDeserializer, BitSerializer},
+    utils::BatchCodec,
+};
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use dsi_bitstream::prelude::*;
+use mmap_rs::MmapFlags;
+use rdst::*;
+
+#[derive(Clone, Debug, Default)]
+/// A codec for encoding and decoding batches of triples using grouped gap compression.
+///
+/// This codec encodes triples of the form `(src, dst, label)` by grouping edges with the same source node,
+/// and encoding the gaps between consecutive sources and destinations using a specified code (default: gamma).
+/// The outdegree (number of edges for each source) is also encoded using the specified code.
+///
+/// ## Type Parameters
+/// - `S`: Serializer for the labels, implementing [`BitSerializer`] for the label type.
+/// - `D`: Deserializer for the labels, implementing [`BitDeserializer`] for the label type.
+/// - `OUTDEGREE_CODE`: Code used for encoding outdegrees (default: gamma).
+/// - `SRC_CODE`: Code used for encoding source gaps (default: gamma).
+/// - `DST_CODE`: Code used for encoding destination gaps (default: gamma).
+///
+/// ## Fields
+/// - `serializer`: The label serializer.
+/// - `deserializer`: The label deserializer.
+///
+/// ## Encoding Format
+/// 1. The batch length is written using delta coding.
+/// 2. For each group of triples with the same source:
+///     - The gap from the previous source is encoded.
+///     - The outdegree (number of edges for this source) is encoded.
+///     - For each destination:
+///         - The gap from the previous destination is encoded.
+///         - The label is serialized.
+///
+/// The bit deserializer must be [`Clone`] because we need one for each
+/// [`GroupedGapsIterator`], and there are possible scenarios in which the
+/// deserializer might be stateful.
+///
+/// ## Choosing the codes
+///
+/// When transposing `enwiki-2024`, these are the top 10 codes for src gaps, outdegree, and dst gaps:
+/// ```ignore
+/// Outdegree stats
+///   Code: ExpGolomb(3) Size: 34004796
+///   Code: ExpGolomb(2) Size: 34101784
+///   Code: ExpGolomb(4) Size: 36036394
+///   Code: Zeta(2)      Size: 36231582
+///   Code: ExpGolomb(1) Size: 36369750
+///   Code: Zeta(3)      Size: 36893285
+///   Code: Pi(2)        Size: 37415701
+///   Code: Zeta(4)      Size: 38905267
+///   Code: Golomb(20)   Size: 38963840
+///   Code: Golomb(19)   Size: 39118201
+/// Src stats
+///   Code: Golomb(2)    Size: 12929998
+///   Code: Rice(1)      Size: 12929998
+///   Code: Unary        Size: 13025332
+///   Code: Golomb(1)    Size: 13025332
+///   Code: Rice(0)      Size: 13025332
+///   Code: ExpGolomb(1) Size: 13319930
+///   Code: Golomb(4)    Size: 18732384
+///   Code: Rice(2)      Size: 18732384
+///   Code: Golomb(3)    Size: 18736573
+///   Code: ExpGolomb(2) Size: 18746122
+/// Dst stats
+///   Code: Pi(2)   Size: 2063880685
+///   Code: Pi(3)   Size: 2074138948
+///   Code: Zeta(3) Size: 2122730298
+///   Code: Zeta(4) Size: 2123948774
+///   Code: Zeta(5) Size: 2169131998
+///   Code: Pi(4)   Size: 2176097847
+///   Code: Zeta(2) Size: 2226573622
+///   Code: Zeta(6) Size: 2237680403
+///   Code: Delta   Size: 2272691460
+///   Code: Zeta(7) Size: 2305354857
+/// ```
+///
+/// The best codes are `Golomb(2)` for src gaps, `ExpGolomb(3)` for outdegree, and `Pi(2)` for dst gaps.
+/// However, `Golomb` can perform poorly if the data don't follow the expected distribution,
+/// so the recommended defaults are `Gamma` for src gaps, `ExpGolomb3` for outdegree, and `Delta` for dst gaps,
+/// as they are universal codes.
+pub struct GroupedGapsCodec<
+    S: BitSerializer<NE, BitWriter> = (),
+    D: BitDeserializer<NE, BitReader, DeserType = S::SerType> + Clone = (),
+    const OUTDEGREE_CODE: usize = { dsi_bitstream::dispatch::code_consts::EXP_GOLOMB3 },
+    const SRC_CODE: usize = { dsi_bitstream::dispatch::code_consts::GAMMA },
+    const DST_CODE: usize = { dsi_bitstream::dispatch::code_consts::DELTA },
+> {
+    /// Serializer for the labels
+    pub serializer: S,
+    /// Deserializer for the labels
+    pub deserializer: D,
+}
+
+impl<S, D, const OUTDEGREE_CODE: usize, const SRC_CODE: usize, const DST_CODE: usize> BatchCodec
+    for GroupedGapsCodec<S, D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+where
+    S: BitSerializer<NE, BitWriter> + Send + Sync,
+    D: BitDeserializer<NE, BitReader, DeserType = S::SerType> + Send + Sync + Clone,
+    S::SerType: Send + Sync + Copy + 'static, // needed by radix sort
+{
+    type Label = S::SerType;
+    type DecodedBatch = GroupedGapsIterator<D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>;
+
+    fn encode_batch(
+        &self,
+        path: impl AsRef<std::path::Path>,
+        batch: &mut [((usize, usize), Self::Label)],
+    ) -> Result<usize> {
+        let start = std::time::Instant::now();
+        Triple::cast_batch_mut(batch).radix_sort_unstable();
+        log::debug!("Sorted {} arcs in {:?}", batch.len(), start.elapsed());
+        self.encode_sorted_batch(path, batch)
+    }
+
+    fn encode_sorted_batch(
+        &self,
+        path: impl AsRef<std::path::Path>,
+        batch: &[((usize, usize), Self::Label)],
+    ) -> Result<usize> {
+        debug_assert!(Triple::cast_batch(batch).is_sorted(), "Batch is not sorted");
+        // create a batch file where to dump
+        let file_path = path.as_ref();
+        let file = std::io::BufWriter::with_capacity(
+            1 << 16,
+            std::fs::File::create(file_path).with_context(|| {
+                format!(
+                    "Could not create BatchIterator temporary file {}",
+                    file_path.display()
+                )
+            })?,
+        );
+        // create a bitstream to write to the file
+        let mut stream = <BufBitWriter<NE, _>>::new(<WordAdapter<usize, _>>::new(file));
+
+        // prefix the stream with the length of the batch
+        // we use a delta code since it'll be a big number most of the time
+        stream
+            .write_delta(batch.len() as u64)
+            .context("Could not write length")?;
+
+        // dump the triples to the bitstream
+        let mut prev_src = 0;
+        let mut written_bits = 0;
+        let mut i = 0;
+        while i < batch.len() {
+            let ((src, _), _) = batch[i];
+            // write the source gap as gamma
+            written_bits += ConstCode::<SRC_CODE>
+                .write(&mut stream, (src - prev_src) as _)
+                .with_context(|| format!("Could not write {src} after {prev_src}"))?;
+            // figure out how many edges have this source
+            let outdegree = batch[i..].iter().take_while(|t| t.0 .0 == src).count();
+            // write the outdegree
+            written_bits += ConstCode::<OUTDEGREE_CODE>
+                .write(&mut stream, outdegree as _)
+                .with_context(|| format!("Could not write outdegree {outdegree} for {src}"))?;
+
+            // encode the destinations
+            let mut prev_dst = 0;
+            for _ in 0..outdegree {
+                let ((_, dst), label) = &batch[i];
+                // write the destination gap as gamma
+                written_bits += ConstCode::<DST_CODE>
+                    .write(&mut stream, (dst - prev_dst) as _)
+                    .with_context(|| format!("Could not write {dst} after {prev_dst}"))?;
+                // write the label
+                written_bits += self
+                    .serializer
+                    .serialize(label, &mut stream)
+                    .context("Could not serialize label")?;
+                prev_dst = *dst;
+                i += 1;
+            }
+            prev_src = src;
+        }
+        // flush the stream and reset the buffer
+        written_bits += stream.flush().context("Could not flush stream")?;
+
+        Ok(written_bits)
+    }
+
+    fn decode_batch(&self, path: impl AsRef<std::path::Path>) -> Result<Self::DecodedBatch> {
+        // open the file
+        let mut stream = <BufBitReader<NE, _>>::new(MemWordReader::new(ArcMmapHelper(Arc::new(
+            MmapHelper::mmap(
+                path.as_ref(),
+                MmapFlags::TRANSPARENT_HUGE_PAGES | MmapFlags::SEQUENTIAL,
+            )
+            .with_context(|| format!("Could not mmap {}", path.as_ref().display()))?,
+        ))));
+
+        // read the length of the batch (first value in the stream)
+        let len = stream.read_delta().context("Could not read length")? as usize;
+
+        // create the iterator
+        Ok(GroupedGapsIterator {
+            deserializer: self.deserializer.clone(),
+            stream,
+            len,
+            current: 0,
+            src: 0,
+            dst_left: 0,
+            prev_dst: 0,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+/// An iterator over triples encoded with gaps, this is returned by [`GroupedGapsCodec`].
+pub struct GroupedGapsIterator<
+    D: BitDeserializer<NE, BitReader> = (),
+    const OUTDEGREE_CODE: usize = { dsi_bitstream::dispatch::code_consts::GAMMA },
+    const SRC_CODE: usize = { dsi_bitstream::dispatch::code_consts::GAMMA },
+    const DST_CODE: usize = { dsi_bitstream::dispatch::code_consts::GAMMA },
+> {
+    /// Deserializer for the labels
+    deserializer: D,
+    /// Bitstream to read from
+    stream: BitReader,
+    /// Length of the iterator (number of triples)
+    len: usize,
+    /// Current position in the iterator
+    current: usize,
+    /// Current source node
+    src: usize,
+    /// Number of destinations left for the current source
+    dst_left: usize,
+    /// Previous destination node
+    prev_dst: usize,
+}
+
+unsafe impl<
+        D: BitDeserializer<NE, BitReader>,
+        const OUTDEGREE_CODE: usize,
+        const SRC_CODE: usize,
+        const DST_CODE: usize,
+    > SortedIterator for GroupedGapsIterator<D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+{
+}
+
+impl<
+        D: BitDeserializer<NE, BitReader>,
+        const OUTDEGREE_CODE: usize,
+        const SRC_CODE: usize,
+        const DST_CODE: usize,
+    > Iterator for GroupedGapsIterator<D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+{
+    type Item = ((usize, usize), D::DeserType);
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current >= self.len {
+            return None;
+        }
+        if self.dst_left == 0 {
+            // read a new source
+            let src_gap = ConstCode::<SRC_CODE>.read(&mut self.stream).ok()?;
+            self.src += src_gap as usize;
+            // read the outdegree
+            self.dst_left = ConstCode::<OUTDEGREE_CODE>.read(&mut self.stream).ok()? as usize;
+            self.prev_dst = 0;
+        }
+
+        let dst_gap = ConstCode::<DST_CODE>.read(&mut self.stream).ok()?;
+        let label = self.deserializer.deserialize(&mut self.stream).ok()?;
+        self.prev_dst += dst_gap as usize;
+        self.current += 1;
+        self.dst_left -= 1;
+        Some(((self.src, self.prev_dst), label))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+impl<
+        D: BitDeserializer<NE, BitReader>,
+        const OUTDEGREE_CODE: usize,
+        const SRC_CODE: usize,
+        const DST_CODE: usize,
+    > ExactSizeIterator for GroupedGapsIterator<D, OUTDEGREE_CODE, SRC_CODE, DST_CODE>
+{
+    fn len(&self) -> usize {
+        self.len - self.current
+    }
+}

--- a/webgraph/src/utils/batch_codec/mod.rs
+++ b/webgraph/src/utils/batch_codec/mod.rs
@@ -1,0 +1,126 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Tommaso Fontana
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+ */
+
+use anyhow::Result;
+
+use super::ArcMmapHelper;
+use dsi_bitstream::prelude::*;
+use rdst::*;
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::Path;
+
+pub mod gaps;
+pub mod grouped_gaps;
+
+/// The recommended default batch codec for unlabelled batches.
+pub type DefaultBatchCodec = grouped_gaps::GroupedGapsCodec;
+
+pub type BitWriter = BufBitWriter<NE, WordAdapter<usize, BufWriter<File>>>;
+pub type BitReader = BufBitReader<NE, MemWordReader<u32, ArcMmapHelper<u32>>>;
+
+/// A trait for encoding and decoding batches of sorted triples.
+pub trait BatchCodec: Send + Sync {
+    /// The label type of the triples to encode and decode.
+    /// While the bounds are not really necessary, in all the practical cases
+    /// we need them.
+    type Label: Copy + Send + Sync + 'static;
+    //// The type returned by `decode_batch`, the iterator of which yields the
+    //// decoded triples in sorted order.
+    ///
+    /// The type `IntoIter` has to be `Send + Sync + Clone` because most often we want
+    /// to use them in [`SortPairs`](crate::utils::sort_pairs::SortPairs) and
+    /// then in [`ArcListGraph`](crate::graphs::arc_list_graph::ArcListGraph)
+    /// which require them.
+    type DecodedBatch: IntoIterator<
+        Item = ((usize, usize), Self::Label),
+        IntoIter: Send + Sync + Clone,
+    >;
+
+    /// Given a batch of sorted triples, encodes them to disk and returns the number of bits written.
+    fn encode_sorted_batch(
+        &self,
+        path: impl AsRef<Path>,
+        batch: &[((usize, usize), Self::Label)],
+    ) -> Result<usize>;
+
+    /// Given a batch of triples, encodes them to disk and returns the number of bits written.
+    /// The batch needs a mutable reference to allow the coded to sort-in-place if needed.
+    fn encode_batch(
+        &self,
+        path: impl AsRef<Path>,
+        batch: &mut [((usize, usize), Self::Label)],
+    ) -> Result<usize>;
+
+    /// Decodes a batch of triples from disk.
+    /// The returned type's iterator yields the serialized triples in sorted order.
+    fn decode_batch(&self, path: impl AsRef<Path>) -> Result<Self::DecodedBatch>;
+}
+
+/// Convenience alias to extract the iterator type of the decoded batch from a [`BatchCodec`].
+pub type CodecIter<C> = <<C as BatchCodec>::DecodedBatch as IntoIterator>::IntoIter;
+
+/// An arc expressed as a pair of nodes and the associated label.
+///
+/// Equality and order are defined only (lexicographically) on the pair of
+/// nodes.
+///
+/// Since we use this to sort a batch of `(usize, usize, L)` triples, in order to
+/// safely transmute between the two types, Triple HAS TO be `repr(transparent)`
+/// of the same tuple type.
+///
+/// We use this to implement `RadixKey` for sorting batches of triples
+/// using `rdst`.
+#[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
+pub struct Triple<L>(((usize, usize), L));
+
+impl<L> Triple<L> {
+    /// Converts a mutable batch of `((usize, usize), L)` triples into a mutable slice of `Triple<L>`.
+    ///
+    /// This is safe because `Triple` is `repr(transparent)` of the same tuple type.
+    pub fn cast_batch_mut(batch: &mut [((usize, usize), L)]) -> &mut [Triple<L>] {
+        unsafe { std::mem::transmute(batch) }
+    }
+    /// Converts a batch of `((usize, usize), L)` triples into a slice of `Triple<L>`.
+    ///
+    /// This is safe because `Triple` is `repr(transparent)` of the same tuple type.
+    pub fn cast_batch(batch: &[((usize, usize), L)]) -> &[Triple<L>] {
+        unsafe { std::mem::transmute(batch) }
+    }
+}
+
+impl<L> RadixKey for Triple<L> {
+    const LEVELS: usize = 16;
+
+    fn get_level(&self, level: usize) -> u8 {
+        (if level < 8 {
+            self.0 .0 .1 >> ((level % 8) * 8)
+        } else {
+            self.0 .0 .0 >> ((level % 8) * 8)
+        }) as u8
+    }
+}
+
+impl<L> PartialEq for Triple<L> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 .0 == other.0 .0
+    }
+}
+
+impl<L> Eq for Triple<L> {}
+
+impl<L> PartialOrd for Triple<L> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<L> Ord for Triple<L> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0 .0.cmp(&other.0 .0)
+    }
+}

--- a/webgraph/src/utils/batch_codec/mod.rs
+++ b/webgraph/src/utils/batch_codec/mod.rs
@@ -20,6 +20,7 @@
 use anyhow::Result;
 
 use super::ArcMmapHelper;
+use core::fmt::Display;
 use dsi_bitstream::prelude::*;
 use rdst::*;
 use std::fs::File;
@@ -53,6 +54,10 @@ pub trait BatchCodec: Send + Sync {
         IntoIter: Send + Sync + Clone,
     >;
 
+    /// A type representing statistics about the encoded batch.
+    /// This type has to implement `Display` so that we can log it.
+    type EncodedBatchStats: Display;
+
     /// Given a batch of sorted triples, encodes them to disk and returns the
     /// number of bits written.
     ///
@@ -62,7 +67,7 @@ pub trait BatchCodec: Send + Sync {
         &self,
         path: impl AsRef<Path>,
         batch: &[((usize, usize), Self::Label)],
-    ) -> Result<usize>;
+    ) -> Result<(usize, Self::EncodedBatchStats)>;
 
     /// Given a batch of triples, sort them, encodes them to disk, and returns
     /// the number of bits written.
@@ -70,7 +75,7 @@ pub trait BatchCodec: Send + Sync {
         &self,
         path: impl AsRef<Path>,
         batch: &mut [((usize, usize), Self::Label)],
-    ) -> Result<usize>;
+    ) -> Result<(usize, Self::EncodedBatchStats)>;
 
     /// Decodes a batch of triples from disk.
     ///

--- a/webgraph/src/utils/batch_codec/mod.rs
+++ b/webgraph/src/utils/batch_codec/mod.rs
@@ -19,8 +19,8 @@ pub mod grouped_gaps;
 /// The recommended default batch codec for unlabelled batches.
 pub type DefaultBatchCodec = grouped_gaps::GroupedGapsCodec;
 
-pub type BitWriter = BufBitWriter<NE, WordAdapter<usize, BufWriter<File>>>;
-pub type BitReader = BufBitReader<NE, MemWordReader<u32, ArcMmapHelper<u32>>>;
+pub type BitWriter<E> = BufBitWriter<E, WordAdapter<usize, BufWriter<File>>>;
+pub type BitReader<E> = BufBitReader<E, MemWordReader<u32, ArcMmapHelper<u32>>>;
 
 /// A trait for encoding and decoding batches of sorted triples.
 pub trait BatchCodec: Send + Sync {

--- a/webgraph/src/utils/mod.rs
+++ b/webgraph/src/utils/mod.rs
@@ -32,6 +32,9 @@ pub fn temp_dir<P: AsRef<std::path::Path>>(base: P) -> anyhow::Result<PathBuf> {
     }
 }
 
+mod batch_codec;
+pub use batch_codec::*;
+
 mod circular_buffer;
 pub(crate) use circular_buffer::*;
 

--- a/webgraph/src/utils/mod.rs
+++ b/webgraph/src/utils/mod.rs
@@ -218,6 +218,22 @@ impl MemoryUsage {
     }
 }
 
+/// Writes a human-readable representation of a large number using SI prefixes units.
+pub fn humanize(value: f64) -> String {
+    const UNITS: &[&str] = &["", "K", "M", "G", "T", "P", "E"];
+    let mut v = value;
+    let mut unit: usize = 0;
+    while v >= 1000.0 && unit + 1 < UNITS.len() {
+        v /= 1000.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{:.0}{}", v, UNITS[unit])
+    } else {
+        format!("{:.3}{}", v, UNITS[unit])
+    }
+}
+
 /// A structure holding partition iterators and their boundaries.
 ///
 /// This type holds a list of iterators and a list of boundaries, one more

--- a/webgraph/src/utils/sort_pairs.rs
+++ b/webgraph/src/utils/sort_pairs.rs
@@ -164,13 +164,16 @@ impl<C: BatchCodec> SortPairs<C> {
         }
 
         let batch_path = self.tmp_dir.join(format!("{:06x}", self.num_batches));
-        let bit_size = self.batch_codec.encode_batch(batch_path, &mut self.batch)?;
+        let start = std::time::Instant::now();
+        let (bit_size, stats) = self.batch_codec.encode_batch(batch_path, &mut self.batch)?;
         log::info!(
-            "Dumped batch {} with {} arcs ({} bits, {:.2} bits / arc)",
+            "Dumped batch {} with {} arcs ({} bits, {:.2} bits / arc) in {:.3} seconds, stats: {}",
             self.num_batches,
             self.batch.len(),
             bit_size,
-            bit_size as f64 / self.batch.len() as f64
+            bit_size as f64 / self.batch.len() as f64,
+            start.elapsed().as_secs_f64(),
+            stats
         );
         self.last_batch_len = self.batch.len();
         self.batch.clear();

--- a/webgraph/tests/test_transpose.rs
+++ b/webgraph/tests/test_transpose.rs
@@ -12,6 +12,7 @@ use webgraph::graphs::vec_graph::LabeledVecGraph;
 use webgraph::prelude::{transpose, transpose_labeled, transpose_split};
 use webgraph::traits::labels::SequentialLabeling;
 use webgraph::traits::{graph, BitDeserializer, BitSerializer};
+use webgraph::utils::gaps::GapsCodec;
 use webgraph::utils::sort_pairs::{BitReader, BitWriter};
 use webgraph::utils::MemoryUsage;
 
@@ -88,10 +89,24 @@ fn test_transpose_labeled() -> anyhow::Result<()> {
     ];
     let g = LabeledVecGraph::<Payload>::from_arcs(arcs);
 
-    let trans = transpose_labeled(&g, MemoryUsage::BatchSize(3), BS {}, BD {})?;
+    let trans = transpose_labeled(
+        &g,
+        MemoryUsage::BatchSize(3),
+        GapsCodec::<_, _> {
+            serializer: BS {},
+            deserializer: BD {},
+        },
+    )?;
     let g2 = LabeledVecGraph::<Payload>::from_lender(trans.iter());
 
-    let trans = transpose_labeled(&g2, MemoryUsage::BatchSize(3), BS {}, BD {})?;
+    let trans = transpose_labeled(
+        &g2,
+        MemoryUsage::BatchSize(3),
+        GapsCodec::<_, _> {
+            serializer: BS {},
+            deserializer: BD {},
+        },
+    )?;
     let g3 = LabeledVecGraph::<Payload>::from_lender(trans.iter());
 
     let g4 = LabeledVecGraph::from_lender(g.iter());


### PR DESCRIPTION
We had a `BatchIterator` that would both store the batch on disk and load it.

In this PR, I replaced it with a generic trait `BatchCodec` that explicitly defines the `encoding` and `decoding` of batches, allowing for different implementations. The compression format of `BatchIterator` is now done by `GapsCodec`.

This had the nice consequence that now `SortPair`, `ParSortPair`, `transpose`, and `simplify` don't have to be aware of `BitSerializer`, `BitDeserializer`, and memory-mapping.

Moreover, we can now select at compile-time the codes to use (it used to be always Gamma), and there's a new implementation called `GroupedGapsCodec` that, instead of encoding each arc as `<src-gap><dst-gap>`, it encodes groups of arcs with the same source as `<src-gap><outdegree><dst-gap1><dst-gap2>...`.

Here's the effect of these changes on a couple of graphs, running `RUSTFLAGS="-Ctarget-cpu=native" cargo run --release -- transform transpose $GRAPH ${GRAPH}-t`.
The codec codes are: `GapsCodec<SRC_CODE, DST_CODE>`, and `GroupedGaps<OUTDEGREE_CODE, SRC_CODE, DST_CODE>`.


| Graph | Codec | bits / arc | time (s) |
| ----- | ----- | ---------- | -------- |
| `enwiki-2024` | `GapsCodec<Gamma, Gamma>`  | 16.97 | 7.921 |
| `enwiki-2024` | `GapsCodec<Gamma, Delta>`  | 14.23 | 8.273 |
| `enwiki-2024` | `GapsCodec<Unary, Pi(2)>`  | 12.99 | 8.253 |
| `enwiki-2024` | `GapsCodec<Gamma, ExpGolomb(1)>` | 16.13 | 8.588 |
| | | | |
| `enwiki-2024` | `GroupedGaps<Gamma, Gamma, Gamma>`  | 16.24 | 7.500 |
| `enwiki-2024` | `GroupedGaps<Delta, Gamma, Delta>`  | 13.51 | 8.055 |
| `enwiki-2024` | `GroupedGaps<ExpGolomb(3), Gamma, Delta>`  | 13.46 | 8.033 |
| `enwiki-2024` | `GroupedGaps<ExpGolomb(3), Golomb(2), Pi(2)>`  | 12.25 | 7.99 |
| `enwiki-2024` | `GroupedGaps<ExpGolomb(2), ExpGolomb(1), ExpGolomb(1)` | 15.33 | 8.052 |
| | | | |
| `twitter-2010` | `GapsCodec<Gamma, Gamma>` | 19.13 | 80.598 |
| `twitter-2010` | `GapsCodec<Gamma, Delta>` | 15.57 | 84.414 |
| `twitter-2010` | `GapsCodec<Unary, Pi(2)>` | 14.33 | 84.634 |
| `twitter-2010` | `GapsCodec<Gamma, ExpGolomb(1)>` | 18.28 | 85.141 |
| | | | |
| `twitter-2010` | `GroupedGaps<Gamma, Gamma, Gamma>` | 18.32 | 79.156 |
| `twitter-2010` | `GroupedGaps<Delta, Gamma, Delta>` | 14.77 | 83.364 |
| `twitter-2010` | `GroupedGaps<ExpGolomb(3), Gamma, Delta>` | 14.73 | 81.955 |
| `twitter-2010` | `GroupedGaps<ExpGolomb(3), Golomb(2), Pi(2)>` | 13.49 | 81.050 |
| `twitter-2010` | `GroupedGaps<ExpGolomb(2), ExpGolomb(1), ExpGolomb(1)` | 17.43 | 81.351 |
| | | | |
| `eu-2015` | `GapsCodec<Gamma, Gamma>` | 5.55,  | 2'949.72 |
| `eu-2015` | `GapsCodec<Gamma, Delta>` | 6.05 | 2'861.18 |
| `eu-2015` | `GapsCodec<Unary, Pi(2)>` | 6.27 | 2'842.616 |
| `eu-2015` | `GapsCodec<Gamma, ExpGolomb(1)>` | 4.64 | 2'846.274 | 
| | | | |
| `eu-2015` | `GroupedGaps<Gamma, Gamma, Gamma>` | 4.65 | 2'735.416 |
| `eu-2015` | `GroupedGaps<Delta, Gamma, Delta>` | 5.15 | 2'933.321 |
| `eu-2015` | `GroupedGaps<ExpGolomb(3), Gamma, Delta>` | 5.14 | 3'428.260 |
| `eu-2015` | `GroupedGaps<ExpGolomb(3), Golomb(2), Pi(2)>` | 5.20 | 2'886.386 |
| `eu-2015` | `GroupedGaps<ExpGolomb(2), ExpGolomb(1), ExpGolomb(1)` | 3.72 | 2'898.69 |

The time measurements are the average of two runs, except for `eu-2015` where it's only one run. In the first two cases, all arcs fit in a single batch, which might explain why `Unary` is the best code for `src`; however, on larger graphs, I doubt it will remain optimal. Instead, `eu-2015` is split into 30 batches of 3'136'103'168 arcs each.

Given the results above, I believe that `GroupedGaps<ExpGolomb(3), Gamma, Delta>` could be a suitable default that utilises universal codes.
