### PR TITLE
Add missing implementations of Lender::size_hint

### DIFF
--- a/webgraph/src/graphs/permuted_graph.rs
+++ b/webgraph/src/graphs/permuted_graph.rs
@@ -124,6 +124,11 @@ impl<L: Lender + for<'next> NodeLabelsLender<'next, Label = usize>, P: SliceByVa
             )
         })
     }
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<

--- a/webgraph/src/graphs/union_graph.rs
+++ b/webgraph/src/graphs/union_graph.rs
@@ -131,6 +131,21 @@ impl<
             ),
         ))
     }
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min0, max0) = self.0.size_hint();
+        let (min1, max1) = self.1.size_hint();
+        (
+            min0.max(min1),
+            match (max0, max1) {
+                (None, None) => None,
+                (Some(max), None) => Some(max),
+                (None, Some(max)) => Some(max),
+                (Some(max0), Some(max1)) => Some(max0.max(max1)),
+            },
+        )
+    }
 }
 
 impl<

--- a/webgraph/src/labels/proj.rs
+++ b/webgraph/src/labels/proj.rs
@@ -128,6 +128,11 @@ where
             (node, LeftIntoIterator(succ))
         })
     }
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
 }
 
 impl<'a, S: SequentialLabeling> IntoLender for &'a Left<S>
@@ -329,6 +334,11 @@ where
             let (node, succ) = x.into_pair();
             (node, RightIntoIterator(succ))
         })
+    }
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 

--- a/webgraph/src/traits/labels.rs
+++ b/webgraph/src/traits/labels.rs
@@ -370,6 +370,11 @@ impl<L: Lender> Lender for AssumeSortedLender<L> {
     fn next(&mut self) -> Option<Lend<'_, Self>> {
         self.lender.next()
     }
+
+    #[inline(always)]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.lender.size_hint()
+    }
 }
 
 impl<L: ExactSizeLender> ExactSizeLender for AssumeSortedLender<L> {


### PR DESCRIPTION
They are required in order to, among other things, call .take(n) on the lender and not have its .len() panic, because lender::Take::len uses a blanket implementation that calls lender::Take::size_hint [1], which itself calls the underlying size_hint [2]

[1]: https://github.com/WanderLanz/Lender/blob/c6a6865037d4b8fde0dee880a9bb084546b4fe49/lender/src/traits/exact_size.rs#L7

[2]: https://github.com/WanderLanz/Lender/blob/c6a6865037d4b8fde0dee880a9bb084546b4fe49/lender/src/adapters/take.rs#L205