### PR TITLE
par_sort_pairs: Fix error message

### DIFF
--- a/webgraph/src/utils/par_sort_pairs.rs
+++ b/webgraph/src/utils/par_sort_pairs.rs
@@ -326,7 +326,7 @@ impl ParSortPairs {
                 let ((src, dst), label) = pair.map_err(Into::into)?;
                 ensure!(
                     src < self.num_nodes,
-                    "Expected {}, but got {src}",
+                    "Expected {} nodes, but got node id {src}",
                     self.num_nodes
                 );
                 let partition_id = src / num_nodes_per_partition;


### PR DESCRIPTION
Otherwise it can error with 'Expected 293339172, but got 293339172' which is confusing.