### PR TITLE
Remove the temporary chunk files immediately after they are written

### DIFF
--- a/webgraph/src/graphs/bvgraph/comp/impls.rs
+++ b/webgraph/src/graphs/bvgraph/comp/impls.rs
@@ -650,6 +650,7 @@ impl BvCompConfig {
                             graph_path.display()
                         )
                     })?;
+                std::fs::remove_file(chunk_graph_path)?;
 
                 log::debug!(
                     "Copying offsets {} [{}..{}) bits from {} to {}",
@@ -675,6 +676,7 @@ impl BvCompConfig {
                             offsets_path.display()
                         )
                     })?;
+                std::fs::remove_file(chunk_offsets_path)?;
 
                 copy_pl.update_with_count(last_node - first_node + 1);
             }


### PR DESCRIPTION
Hi,
I made a simple modification to the parallel version of the compressor. 
Now, a chunk is deleted as soon as it is written rather than waiting until the end to delete all the chunks at once. Deleting all the chunks at once requires twice the disk space needed to compress a graph (the chunks plus the graph itself).
Now the additional disk space needed is limited to the largest chunk, which can be reduced (inelegantly) by increasing the number of jobs.
In my case, I was able to compress a 200 GB Software Heritage graph (+~40 GB of offsets) with 420 GB of disk space available, which wasn't possible prior to this modification.