### PR TITLE
ci: run the Rust and Miri workflows only for main pushes and PRs

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -2,9 +2,9 @@ name: Miri
 
 on:
   push:
-    branches:
+    branches: ["main"]
   pull_request:
-    branches:
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust CI Pipeline
 
 on:
   push:
-    branches:
+    branches: ["main"]
   pull_request:
-    branches:
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
`rust.yml` and `miri.yml` declared empty `branches:` filters under both `push` and `pull_request`, so every push to a PR branch triggered **both** the `push` and the `pull_request` event (and tag pushes triggered extra runs too), duplicating every Rust CI and Miri check.

This scopes both workflows to the `main` branch, matching the existing `llp.yml`, so a pull request runs each check exactly once (via `pull_request`) and only pushes to `main` run the `push`-event checks.

```yaml
on:
  push:
    branches: ["main"]
  pull_request:
    branches: ["main"]
```

Follow-up to #171 (the empty filters predate it; this was noticed on that PR's duplicated runs). `llp.yml` already used this pattern and was unaffected; `build_artifact.yml` triggers only on `release` and is untouched. This PR itself demonstrates the fix — Rust CI and Miri each trigger a single `pull_request` run.